### PR TITLE
Introduce NotUnmarshallableXmlAdapter to save the repeated non-implementation of unmarshal

### DIFF
--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/BooleanAliasTypeAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/BooleanAliasTypeAdapter.java
@@ -31,13 +31,7 @@ package org.musicbrainz.search.solrwriter.moxy;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class BooleanAliasTypeAdapter extends XmlAdapter<Boolean, String> {
-
-    @Override
-    public String unmarshal(Boolean v) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
+public class BooleanAliasTypeAdapter extends NotUnmarshallableXmlAdapter<Boolean, String> {
     @Override
     public Boolean marshal(String v) throws Exception {
         if (v == null) {

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/EventAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/EventAdapter.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.util.ArrayList;
 import java.util.List;
 
-public class EventAdapter extends XmlAdapter<EventAdapter.AdaptedEvent, Event> {
+public class EventAdapter extends NotUnmarshallableXmlAdapter<EventAdapter.AdaptedEvent, Event> {
 
     public static class AdaptedEvent extends Event {
         public List<Relation> relations = new ArrayList<Relation>();
@@ -50,7 +50,6 @@ public class EventAdapter extends XmlAdapter<EventAdapter.AdaptedEvent, Event> {
      */
     @Override
     public AdaptedEvent marshal(Event event) throws Exception {
-        
         AdaptedEvent adaptedEvent = new AdaptedEvent();
         for(RelationList relationList : event.getRelationList()) {
             for(Relation relation : relationList.getRelation()) {
@@ -73,14 +72,5 @@ public class EventAdapter extends XmlAdapter<EventAdapter.AdaptedEvent, Event> {
         adaptedEvent.setUserTagList(event.getUserTagList());
         return adaptedEvent;
     }
-
-    /*
-    Not used in Search Server
-     */
-    @Override
-    public Event unmarshal(AdaptedEvent adaptedEvent) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
 }
 

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/NotUnmarshallableXmlAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/NotUnmarshallableXmlAdapter.java
@@ -1,0 +1,13 @@
+package org.musicbrainz.search.solrwriter.moxy;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+public abstract class NotUnmarshallableXmlAdapter<T1, T2> extends XmlAdapter<T1, T2> {
+    /*
+    Not used in Search Server
+     */
+    @Override
+    public T2 unmarshal(T1 _) throws Exception {
+        throw new UnsupportedOperationException("Unmarshalling json back to model is not supported");
+    }
+}

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringFormatAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringFormatAdapter.java
@@ -32,13 +32,7 @@ import org.musicbrainz.mmd2.Format;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class StringFormatAdapter extends XmlAdapter<String, Format> {
-
-    @Override
-    public Format unmarshal(String v) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
+public class StringFormatAdapter extends NotUnmarshallableXmlAdapter<String, Format> {
     @Override
     public String marshal(Format v) throws Exception {
         return v.getContent();

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringGenderAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringGenderAdapter.java
@@ -32,13 +32,7 @@ import org.musicbrainz.mmd2.Gender;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class StringGenderAdapter extends XmlAdapter<String, Gender> {
-
-    @Override
-    public Gender unmarshal(String v) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
+public class StringGenderAdapter extends NotUnmarshallableXmlAdapter<String, Gender> {
     @Override
     public String marshal(Gender v) throws Exception {
         return v.getContent();

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringPrimaryTypeAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringPrimaryTypeAdapter.java
@@ -32,13 +32,7 @@ import org.musicbrainz.mmd2.PrimaryType;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class StringPrimaryTypeAdapter extends XmlAdapter<String, PrimaryType> {
-
-    @Override
-    public PrimaryType unmarshal(String v) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
+public class StringPrimaryTypeAdapter extends NotUnmarshallableXmlAdapter<String, PrimaryType> {
     @Override
     public String marshal(PrimaryType v) throws Exception {
         return v.getContent();

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringSecondaryTypeAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringSecondaryTypeAdapter.java
@@ -32,13 +32,7 @@ import org.musicbrainz.mmd2.SecondaryType;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class StringSecondaryTypeAdapter extends XmlAdapter<String, SecondaryType> {
-
-    @Override
-    public SecondaryType unmarshal(String v) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
+public class StringSecondaryTypeAdapter extends NotUnmarshallableXmlAdapter<String, SecondaryType> {
     @Override
     public String marshal(SecondaryType v) throws Exception {
         return v.getContent();

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringStatusAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringStatusAdapter.java
@@ -32,13 +32,7 @@ import org.musicbrainz.mmd2.Status;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class StringStatusAdapter extends XmlAdapter<String, Status> {
-
-    @Override
-    public Status unmarshal(String v) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
+public class StringStatusAdapter extends NotUnmarshallableXmlAdapter<String, Status> {
     @Override
     public String marshal(Status v) throws Exception {
         return v.getContent();

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringTargetAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/StringTargetAdapter.java
@@ -32,13 +32,7 @@ import org.musicbrainz.mmd2.Target;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
-public class StringTargetAdapter extends XmlAdapter<String, Target> {
-
-    @Override
-    public Target unmarshal(String v) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
+public class StringTargetAdapter extends NotUnmarshallableXmlAdapter<String, Target> {
     @Override
     public String marshal(Target v) throws Exception {
         return v.getValue();

--- a/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/WorkAdapter.java
+++ b/mb-solrquerywriter/src/main/java/org/musicbrainz/search/solrwriter/moxy/WorkAdapter.java
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.util.ArrayList;
 import java.util.List;
 
-public class WorkAdapter extends XmlAdapter<WorkAdapter.AdaptedWork, Work> {
+public class WorkAdapter extends NotUnmarshallableXmlAdapter<WorkAdapter.AdaptedWork, Work> {
 
     public static class AdaptedWork extends Work {
         public List<Relation> relations = new ArrayList<Relation>();
@@ -80,13 +80,4 @@ public class WorkAdapter extends XmlAdapter<WorkAdapter.AdaptedWork, Work> {
         adaptedWork.setUserTagList(work.getUserTagList());
         return adaptedWork;
     }
-
-    /*
-    Not used in Search Server
-     */
-    @Override
-    public Work unmarshal(AdaptedWork adaptedWork) throws Exception {
-        throw new UnsupportedOperationException("Umarshalling json back to model not supported");
-    }
-
 }


### PR DESCRIPTION
Also fixes the typo "Umarshalling" -> "Unmarshalling" in the exception
message.