### PR TITLE
Fix building from Solr 7.7.2 with Alpine Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 mb-solr/target*
 .idea/
 *.iml
+/build-*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:7.7.2-alpine
+FROM metabrainz/solr:7.7.2-alpine
 
 # Resetting value set in the parent image
 USER root

--- a/push.sh
+++ b/push.sh
@@ -1,4 +1,64 @@
-#!/bin/sh
+#!/bin/bash
+#
+# Build image from the currently checked out version of
+# MusicBrainz Solr search server (mb-solr)
+# and push it to Docker Hub, tagged with versions and variants.
+#
+# Examples:
+# - working tree at git tag v3.1.1 will push docker tags :3.1.1 :3.1 and :3
+# - working tree at git tag v3.1.1-rc.1 will push docker tag :3.1.1-rc.1 only
+# - untagged working tree v3.1-1-gbfe66e3 will push docker tag 3.1.1-gbfe66e3 only
+# - uncommitted/dirty working tree v3.1-dirty will push docker tag :3.1-dirty only
+#
+# Usage:
+#   $ ./push.sh
 
-docker build -t metabrainz/solr .
-docker push metabrainz/solr
+set -e -u
+
+image_name='metabrainz/mb-solr'
+
+cd "$(dirname "${BASH_SOURCE[0]}")/"
+
+vcs_ref=`git describe --always --broken --dirty --tags`
+version=${vcs_ref#v}
+
+# enforce version format major.minor.patch if possible
+if [[ $version =~ ^[0-9]+$ ]]; then
+  version="${version}.0.0"
+  echo "$0: appended .0.0 to version"
+elif [[ $version =~ ^[0-9]+\.[0-9]+$ ]]; then
+  version="${version}.0"
+  echo "$0: appended .0 to version"
+fi
+
+# add aliases if version is of format major.minor.patch
+if [[ $version =~ ^([0-9]+)\.([0-9]+)\.[0-9]\+$ ]]; then
+  major=${BASH_REMATCH[1]}
+  minor=${BASH_REMATCH[2]}
+  version_aliases=( "${major}.${minor}" "${major}" )
+  echo "$0: building version '$version' with aliases:"
+  for version_alias in ${version_aliases[@]}; do
+    echo "$0: - '$version_alias'"
+  done
+else
+  version_aliases=()
+  echo "$0: building version '$version' without alias"
+fi
+
+tag=${version}
+tag_aliases=${version_aliases[@]}
+timestamp=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+docker build \
+  --build-arg MB_SOLR_VERSION=${version} \
+  --build-arg BUILD_DATE=${timestamp} \
+  --build-arg VCS_REF=${vcs_ref} \
+  --tag ${image_name}:${tag} . \
+  | tee ./"build-${version}-at-${timestamp}.log"
+
+docker push ${image_name}:${tag}
+
+for tag_alias in ${tag_aliases[@]}; do
+  docker tag ${image_name}:${tag} metabrainz/mb-solr:${tag_alias}
+  docker push ${image_name}:${tag_alias}
+done


### PR DESCRIPTION
Since version '7.7.2', the official Solr images support neither OpenJDK 8 nor the lightweight '-alpine' variant any longer.

In commit https://github.com/metabrainz/mb-solr/pull/33/commits/c8bee45cf5cde937bb3d6821ab887947aebff615, hese are replaced by `metabrainz/solr` in-house image (`7.2.2-alpine`) based on `adoptopenjdk/openjdk8` image (`jre-alpine`). See https://github.com/metabrainz/docker-openjdk8-solr7

----

Maven was installed from Alpine Linux packages so as to install Java bindings for MB Metadata Schema (`mmd-schema`) and MB Query Response Writer (whose cores are defined by `mbsssss`).

As a bonus, commit https://github.com/metabrainz/mb-solr/pull/33/commits/7a7726c9f80f3a0e9569512900c4d3be29ad2d32 splits the build into two stages:
- first stage is based on 'maven' official image (3.6.1-jdk-8)
- second stage is based on 'metabrainz/solr' image (7.2.2-alpine)

This way, final built image is smaller as it doesn't contain Maven.

Versions, git ref, and build date have been added to image labels.
Release script also updates tags with major and minor versions.