### PR TITLE
Allow to build Docker image for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ COPY ./mb-solr/pom.xml mb-solr/pom.xml
 COPY ./mmd-schema/brainz-mmd2-jaxb/pom.xml brainz-mmd2-jaxb/pom.xml
 RUN cd brainz-mmd2-jaxb && \
     mvn verify clean --fail-never && \
+    echo BUILD SUCCESS is expected above && \
     cd ../mb-solr && \
     mvn verify clean --fail-never && \
-    cd ..
+    echo BUILD FAILURE is expected above because brainz-mmd-jaxb is not installed yet
 
 COPY ./mmd-schema/brainz-mmd2-jaxb brainz-mmd2-jaxb
 COPY ./mb-solr mb-solr

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ QueryResponseWriter is available on
 
 ## Docker Installation
 
-Simply run
+Clone the repository with Git:
+
+    git clone --recursive https://github.com/metabrainz/mb-solr.git
+
+Either run it alone on port 8983:
 
     docker-compose up
+
+Or build a tagged image to run with [MusicBrainz Docker](https://github.com/metabrainz/musicbrainz-docker):
+
+    ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Build image from the currently checked out version of
+# MusicBrainz Solr search server (mb-solr).
+#
+# Examples:
+# - working tree at git tag v3.1.1 will build docker tag :3.1.1 only
+# - working tree at git tag v3.1.1-rc.1 will build docker tag :3.1.1-rc.1 only
+# - untagged working tree v3.1-1-gbfe66e3 will build docker tag 3.1.1-gbfe66e3 only
+# - uncommitted/dirty working tree v3.1-dirty will build docker tag :3.1-dirty only
+#
+# This script is purposed for contributors.
+#
+# It is also called from `push.sh` which is for maintainers only.
+#
+# Usage:
+#   $ ./build.sh
+
+set -e -u
+
+image_name='metabrainz/mb-solr'
+
+cd "$(dirname "${BASH_SOURCE[0]}")/"
+
+DOCKER_CMD=${DOCKER_CMD:-docker}
+vcs_ref=`git describe --always --broken --dirty --tags`
+version=${vcs_ref#v}
+
+# enforce version format major.minor.patch if possible
+if [[ $version =~ ^[0-9]+$ ]]; then
+  version="${version}.0.0"
+  echo "$0: appended .0.0 to version"
+elif [[ $version =~ ^[0-9]+\.[0-9]+$ ]]; then
+  version="${version}.0"
+  echo "$0: appended .0 to version"
+fi
+
+tag=${version}
+timestamp=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+${DOCKER_CMD} build \
+  --build-arg MB_SOLR_VERSION=${version} \
+  --build-arg BUILD_DATE=${timestamp} \
+  --build-arg VCS_REF=${vcs_ref} \
+  --tag ${image_name}:${tag} . \
+  | tee ./"build-${version}-at-${timestamp}.log"
+

--- a/push.sh
+++ b/push.sh
@@ -10,6 +10,8 @@
 # - untagged working tree v3.1-1-gbfe66e3 will push docker tag 3.1.1-gbfe66e3 only
 # - uncommitted/dirty working tree v3.1-dirty will push docker tag :3.1-dirty only
 #
+# This script is purposed for maintainers only, not contributors.
+#
 # Usage:
 #   $ ./push.sh
 
@@ -48,14 +50,8 @@ fi
 
 tag=${version}
 tag_aliases=${version_aliases[@]}
-timestamp=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
-${DOCKER_CMD} build \
-  --build-arg MB_SOLR_VERSION=${version} \
-  --build-arg BUILD_DATE=${timestamp} \
-  --build-arg VCS_REF=${vcs_ref} \
-  --tag ${image_name}:${tag} . \
-  | tee ./"build-${version}-at-${timestamp}.log"
+./build.sh
 
 ${DOCKER_CMD} push ${image_name}:${tag}
 

--- a/push.sh
+++ b/push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Build image from the currently checked out version of
 # MusicBrainz Solr search server (mb-solr)


### PR DESCRIPTION
# Problem

The existing script `push.sh` requires maintainer privileges to push image to Docker Hub.
Unpriliveged contributors still need to build a local image for test.

# Solution

This patch just splits `push.sh` to call `build.sh` rather than to build image.
The new script `build.sh` can be run by any contributor. It allows to build a custom image from the local working copy of `mb-solr`. This image can then be used in [development setup of `musicbrainz-docker`](https://github.com/metabrainz/musicbrainz-docker#development-setup) by setting the Docker Compose environment variable `MB_SOLR_VERSION` appropriately in `.env`.