### PR TITLE
Improve readability of XML resource files used in the tests

### DIFF
--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/MBXMLWriterTestInterface.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/MBXMLWriterTestInterface.java
@@ -25,9 +25,10 @@ public interface MBXMLWriterTestInterface extends MBWriterTestInterface {
 		Source test = Input.fromString(actual).build();
 
 		Diff d = DiffBuilder.compare(Input.fromString(expected))
+				.ignoreWhitespace()
+				.ignoreComments()
 				.withTest(test)
-				.withAttributeFilter
-						(MBXMLWriterTestInterface::cannotSkipAttribute)
+				.withAttributeFilter(MBXMLWriterTestInterface::cannotSkipAttribute)
 				.build();
 		if (d.hasDifferences()) {
 			for (Difference diff : d.getDifferences()) {

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/area-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/area-list.xml
@@ -1,1 +1,29 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0" xmlns="http://musicbrainz.org/ns/mmd-2.0#"><area-list count="1" offset="0"><area id="ff2ee1ad-febe-4b48-8999-e77870b62744" type="Subdivision" ns2:score="100"><name>Thüringen</name><sort-name>Thüringen</sort-name><iso-3166-2-code-list><iso-3166-2-code>DE-TH</iso-3166-2-code></iso-3166-2-code-list><life-span><ended>false</ended></life-span><alias-list><alias locale="de" sort-name="Thüringen" type="Area name" primary="primary">Thüringen</alias><alias locale="en" sort-name="Thuringia" type="Area name" primary="primary">Thuringia</alias></alias-list><relation-list target-type="area"><relation type="part of" type-id="de7cc874-8b1b-3a05-8272-f3834c968fb7"><target>85752fda-13c4-31a3-bee5-0e5cb1f51dad</target><direction>backward</direction><area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad" type="Country"><name>Germany</name><sort-name>Germany</sort-name></area></relation></relation-list></area></area-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0" xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <area-list count="1" offset="0">
+        <area id="ff2ee1ad-febe-4b48-8999-e77870b62744" type="Subdivision" ns2:score="100">
+            <name>Thüringen</name>
+            <sort-name>Thüringen</sort-name>
+            <iso-3166-2-code-list>
+                <iso-3166-2-code>DE-TH</iso-3166-2-code>
+            </iso-3166-2-code-list>
+            <life-span>
+                <ended>false</ended>
+            </life-span>
+            <alias-list>
+                <alias locale="de" sort-name="Thüringen" type="Area name" primary="primary">Thüringen</alias>
+                <alias locale="en" sort-name="Thuringia" type="Area name" primary="primary">Thuringia</alias>
+            </alias-list>
+            <relation-list target-type="area">
+                <relation type="part of" type-id="de7cc874-8b1b-3a05-8272-f3834c968fb7">
+                    <target>85752fda-13c4-31a3-bee5-0e5cb1f51dad</target>
+                    <direction>backward</direction>
+                    <area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad" type="Country">
+                        <name>Germany</name>
+                        <sort-name>Germany</sort-name>
+                    </area>
+                </relation>
+            </relation-list>
+        </area>
+    </area-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/area.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/area.xml
@@ -1,1 +1,26 @@
-<area-list xmlns="http://musicbrainz.org/ns/mmd-2.0#"><area id="ff2ee1ad-febe-4b48-8999-e77870b62744" type="Subdivision"><name>Thüringen</name><sort-name>Thüringen</sort-name><iso-3166-2-code-list><iso-3166-2-code>DE-TH</iso-3166-2-code></iso-3166-2-code-list><life-span><ended>false</ended></life-span><alias-list><alias locale="de" sort-name="Thüringen" type="Area name" primary="primary">Thüringen</alias><alias locale="en" sort-name="Thuringia" type="Area name" primary="primary">Thuringia</alias></alias-list><relation-list target-type="area"><relation type="part of" type-id="de7cc874-8b1b-3a05-8272-f3834c968fb7"><target>85752fda-13c4-31a3-bee5-0e5cb1f51dad</target><direction>backward</direction><area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad" type="Country"><name>Germany</name><sort-name>Germany</sort-name></area></relation></relation-list></area></area-list>
+<area-list xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <area id="ff2ee1ad-febe-4b48-8999-e77870b62744" type="Subdivision">
+        <name>Thüringen</name>
+        <sort-name>Thüringen</sort-name>
+        <iso-3166-2-code-list>
+            <iso-3166-2-code>DE-TH</iso-3166-2-code>
+        </iso-3166-2-code-list>
+        <life-span>
+            <ended>false</ended>
+        </life-span>
+        <alias-list>
+            <alias locale="de" sort-name="Thüringen" type="Area name" primary="primary">Thüringen</alias>
+            <alias locale="en" sort-name="Thuringia" type="Area name" primary="primary">Thuringia</alias>
+        </alias-list>
+        <relation-list target-type="area">
+            <relation type="part of" type-id="de7cc874-8b1b-3a05-8272-f3834c968fb7">
+                <target>85752fda-13c4-31a3-bee5-0e5cb1f51dad</target>
+                <direction>backward</direction>
+                <area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad" type="Country">
+                    <name>Germany</name>
+                    <sort-name>Germany</sort-name>
+                </area>
+            </relation>
+        </relation-list>
+    </area>
+</area-list>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/artist-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/artist-list.xml
@@ -1,1 +1,61 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0" xmlns="http://musicbrainz.org/ns/mmd-2.0#"><artist-list count="1" offset="0"><artist id="9b58672a-e68e-4972-956e-a8985a165a1f" type="Person" ns2:score="100"><name>Howard Shore</name><sort-name>Shore, Howard</sort-name><country>CA</country><area id="71bbafaa-e825-3e15-8ca9-017dcad1748b"><name>Canada</name><sort-name>Canada</sort-name></area><begin-area id="74b24e62-d2fe-42d2-9d96-31f2da756c77"><name>Toronto</name><sort-name>Toronto</sort-name></begin-area><disambiguation></disambiguation><life-span><begin>1946-10-18</begin><end></end><ended>false</ended></life-span><alias-list><alias sort-name="Shore">Shore</alias><alias sort-name="Howard Shaw">Howard Shaw</alias><alias sort-name="H. Shore">H. Shore</alias></alias-list><tag-list count="10"><tag count="1"><name>lord of the rings</name></tag><tag count="2"><name>classical</name></tag><tag count="2"><name>canadian</name></tag><tag count="1"><name>film composer</name></tag><tag count="1"><name>score</name></tag><tag count="1"><name>academy award winner</name></tag><tag count="1"><name>easy listening soundtracks and musicals</name></tag><tag count="2"><name>soundtrack</name></tag><tag count="1"><name>howard</name></tag><tag count="1"><name>shore</name></tag></tag-list></artist></artist-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0" xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <artist-list count="1" offset="0">
+        <artist id="9b58672a-e68e-4972-956e-a8985a165a1f" type="Person" ns2:score="100">
+            <name>Howard Shore</name>
+            <sort-name>Shore, Howard</sort-name>
+            <country>CA</country>
+            <area id="71bbafaa-e825-3e15-8ca9-017dcad1748b">
+                <name>Canada</name>
+                <sort-name>Canada</sort-name>
+            </area>
+            <begin-area id="74b24e62-d2fe-42d2-9d96-31f2da756c77">
+                <name>Toronto</name>
+                <sort-name>Toronto</sort-name>
+            </begin-area>
+            <disambiguation></disambiguation>
+            <life-span>
+                <begin>1946-10-18</begin>
+                <end></end>
+                <ended>false</ended>
+            </life-span>
+            <alias-list>
+                <alias sort-name="Shore">Shore</alias>
+                <alias sort-name="Howard Shaw">Howard Shaw</alias>
+                <alias sort-name="H. Shore">H. Shore</alias>
+            </alias-list>
+            <tag-list count="10">
+                <tag count="1">
+                    <name>lord of the rings</name>
+                </tag>
+                <tag count="2">
+                    <name>classical</name>
+                </tag>
+                <tag count="2">
+                    <name>canadian</name>
+                </tag>
+                <tag count="1">
+                    <name>film composer</name>
+                </tag>
+                <tag count="1">
+                    <name>score</name>
+                </tag>
+                <tag count="1">
+                    <name>academy award winner</name>
+                </tag>
+                <tag count="1">
+                    <name>easy listening soundtracks and musicals</name>
+                </tag>
+                <tag count="2">
+                    <name>soundtrack</name>
+                </tag>
+                <tag count="1">
+                    <name>howard</name>
+                </tag>
+                <tag count="1">
+                    <name>shore</name>
+                </tag>
+            </tag-list>
+        </artist>
+    </artist-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/artist.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/artist.xml
@@ -1,1 +1,56 @@
-<artist xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="9b58672a-e68e-4972-956e-a8985a165a1f" type="Person"><name>Howard Shore</name><sort-name>Shore, Howard</sort-name><country>CA</country><area id="71bbafaa-e825-3e15-8ca9-017dcad1748b"><name>Canada</name><sort-name>Canada</sort-name></area><begin-area id="74b24e62-d2fe-42d2-9d96-31f2da756c77"><name>Toronto</name><sort-name>Toronto</sort-name></begin-area><disambiguation></disambiguation><life-span><begin>1946-10-18</begin><end></end><ended>false</ended></life-span><alias-list><alias sort-name="Shore">Shore</alias><alias sort-name="Howard Shaw">Howard Shaw</alias><alias sort-name="H. Shore">H. Shore</alias></alias-list><tag-list count="10"><tag count="1"><name>lord of the rings</name></tag><tag count="2"><name>classical</name></tag><tag count="2"><name>canadian</name></tag><tag count="1"><name>film composer</name></tag><tag count="1"><name>score</name></tag><tag count="1"><name>academy award winner</name></tag><tag count="1"><name>easy listening soundtracks and musicals</name></tag><tag count="2"><name>soundtrack</name></tag><tag count="1"><name>howard</name></tag><tag count="1"><name>shore</name></tag></tag-list></artist>
+<artist xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="9b58672a-e68e-4972-956e-a8985a165a1f" type="Person">
+    <name>Howard Shore</name>
+    <sort-name>Shore, Howard</sort-name>
+    <country>CA</country>
+    <area id="71bbafaa-e825-3e15-8ca9-017dcad1748b">
+        <name>Canada</name>
+        <sort-name>Canada</sort-name>
+    </area>
+    <begin-area id="74b24e62-d2fe-42d2-9d96-31f2da756c77">
+        <name>Toronto</name>
+        <sort-name>Toronto</sort-name>
+    </begin-area>
+    <disambiguation></disambiguation>
+    <life-span>
+        <begin>1946-10-18</begin>
+        <end></end>
+        <ended>false</ended>
+    </life-span>
+    <alias-list>
+        <alias sort-name="Shore">Shore</alias>
+        <alias sort-name="Howard Shaw">Howard Shaw</alias>
+        <alias sort-name="H. Shore">H. Shore</alias>
+    </alias-list>
+    <tag-list count="10">
+        <tag count="1">
+            <name>lord of the rings</name>
+        </tag>
+        <tag count="2">
+            <name>classical</name>
+        </tag>
+        <tag count="2">
+            <name>canadian</name>
+        </tag>
+        <tag count="1">
+            <name>film composer</name>
+        </tag>
+        <tag count="1">
+            <name>score</name>
+        </tag>
+        <tag count="1">
+            <name>academy award winner</name>
+        </tag>
+        <tag count="1">
+            <name>easy listening soundtracks and musicals</name>
+        </tag>
+        <tag count="2">
+            <name>soundtrack</name>
+        </tag>
+        <tag count="1">
+            <name>howard</name>
+        </tag>
+        <tag count="1">
+            <name>shore</name>
+        </tag>
+    </tag-list>
+</artist>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/cdstub-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/cdstub-list.xml
@@ -1,1 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><cdstub-list count="1" offset="0"><cdstub id="zsXyqGWvw0zF024A_saTokxIMzo-" ns2:score="100"><title>Doo-lang Doo-lang</title><artist>The Emergency</artist><barcode>700261200910</barcode><disambiguation>CD Baby id:emergency2</disambiguation><track-list count="16"/></cdstub></cdstub-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <cdstub-list count="1" offset="0">
+        <cdstub id="zsXyqGWvw0zF024A_saTokxIMzo-" ns2:score="100">
+            <title>Doo-lang Doo-lang</title>
+            <artist>The Emergency</artist>
+            <barcode>700261200910</barcode>
+            <disambiguation>CD Baby id:emergency2</disambiguation>
+            <track-list count="16"/>
+        </cdstub>
+    </cdstub-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/cdstub.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/cdstub.xml
@@ -1,1 +1,7 @@
-<cdstub xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="zsXyqGWvw0zF024A_saTokxIMzo-"><title>Doo-lang Doo-lang</title><artist>The Emergency</artist><barcode>700261200910</barcode><disambiguation>CD Baby id:emergency2</disambiguation><track-list count="16"/></cdstub>
+<cdstub xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="zsXyqGWvw0zF024A_saTokxIMzo-">
+    <title>Doo-lang Doo-lang</title>
+    <artist>The Emergency</artist>
+    <barcode>700261200910</barcode>
+    <disambiguation>CD Baby id:emergency2</disambiguation>
+    <track-list count="16"/>
+</cdstub>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/editor-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/editor-list.xml
@@ -1,1 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><editor-list count="1" offset="0"><editor ns2:score="100"><name>Mineo</name><bio>Nothing to see here!</bio></editor></editor-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <editor-list count="1" offset="0">
+        <editor ns2:score="100">
+            <name>Mineo</name>
+            <bio>Nothing to see here!</bio>
+        </editor>
+    </editor-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/editor.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/editor.xml
@@ -1,1 +1,4 @@
-<editor xmlns="http://musicbrainz.org/ns/mmd-2.0#"><name>Mineo</name><bio>Nothing to see here!</bio></editor>
+<editor xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+    <name>Mineo</name>
+    <bio>Nothing to see here!</bio>
+</editor>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/label-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/label-list.xml
@@ -1,1 +1,39 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><label-list count="1" offset="0"><label id="5a584032-dcef-41bb-9f8b-19540116fb1c" type="Original Production" ns2:score="100"><name>Deutsche Grammophon</name><sort-name>Deutsche Grammophon</sort-name><label-code>173</label-code><country>DE</country><area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad"><name>Germany</name><sort-name>Germany</sort-name></area><life-span><begin>1898</begin><ended>false</ended></life-span><alias-list><alias sort-name="Deutsche Grammaphon">Deutsche Grammaphon</alias><alias sort-name="Deutsche Grammophone">Deutsche Grammophone</alias><alias sort-name="Deutsche Grammophon Gesellschaft">Deutsche Grammophon Gesellschaft</alias><alias sort-name="Deutsche Grammophon GmbH">Deutsche Grammophon GmbH</alias><alias sort-name="Deutsche Grammophon (Universal)">Deutsche Grammophon (Universal)</alias><alias sort-name="Deutsche Gramophon">Deutsche Gramophon</alias><alias sort-name="DG">DG</alias></alias-list><tag-list><tag count="2"><name>classical</name></tag><tag count="1"><name>tomatito</name></tag><tag count="1"><name>deutsche grammophon beethoven</name></tag></tag-list></label></label-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <label-list count="1" offset="0">
+        <label id="5a584032-dcef-41bb-9f8b-19540116fb1c" type="Original Production" ns2:score="100">
+            <name>Deutsche Grammophon</name>
+            <sort-name>Deutsche Grammophon</sort-name>
+            <label-code>173</label-code>
+            <country>DE</country>
+            <area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad">
+                <name>Germany</name>
+                <sort-name>Germany</sort-name>
+            </area>
+            <life-span>
+                <begin>1898</begin>
+                <ended>false</ended>
+            </life-span>
+            <alias-list>
+                <alias sort-name="Deutsche Grammaphon">Deutsche Grammaphon</alias>
+                <alias sort-name="Deutsche Grammophone">Deutsche Grammophone</alias>
+                <alias sort-name="Deutsche Grammophon Gesellschaft">Deutsche Grammophon Gesellschaft</alias>
+                <alias sort-name="Deutsche Grammophon GmbH">Deutsche Grammophon GmbH</alias>
+                <alias sort-name="Deutsche Grammophon (Universal)">Deutsche Grammophon (Universal)</alias>
+                <alias sort-name="Deutsche Gramophon">Deutsche Gramophon</alias>
+                <alias sort-name="DG">DG</alias>
+            </alias-list>
+            <tag-list>
+                <tag count="2">
+                    <name>classical</name>
+                </tag>
+                <tag count="1">
+                    <name>tomatito</name>
+                </tag>
+                <tag count="1">
+                    <name>deutsche grammophon beethoven</name>
+                </tag>
+            </tag-list>
+        </label>
+    </label-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/label.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/label.xml
@@ -1,1 +1,34 @@
-<label xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="5a584032-dcef-41bb-9f8b-19540116fb1c" type="Original Production"><name>Deutsche Grammophon</name><sort-name>Deutsche Grammophon</sort-name><label-code>173</label-code><country>DE</country><area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad"><name>Germany</name><sort-name>Germany</sort-name></area><life-span><begin>1898</begin><ended>false</ended></life-span><alias-list><alias sort-name="Deutsche Grammaphon">Deutsche Grammaphon</alias><alias sort-name="Deutsche Grammophone">Deutsche Grammophone</alias><alias sort-name="Deutsche Grammophon Gesellschaft">Deutsche Grammophon Gesellschaft</alias><alias sort-name="Deutsche Grammophon GmbH">Deutsche Grammophon GmbH</alias><alias sort-name="Deutsche Grammophon (Universal)">Deutsche Grammophon (Universal)</alias><alias sort-name="Deutsche Gramophon">Deutsche Gramophon</alias><alias sort-name="DG">DG</alias></alias-list><tag-list><tag count="2"><name>classical</name></tag><tag count="1"><name>tomatito</name></tag><tag count="1"><name>deutsche grammophon beethoven</name></tag></tag-list></label>
+<label xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="5a584032-dcef-41bb-9f8b-19540116fb1c" type="Original Production">
+    <name>Deutsche Grammophon</name>
+    <sort-name>Deutsche Grammophon</sort-name>
+    <label-code>173</label-code>
+    <country>DE</country>
+    <area id="85752fda-13c4-31a3-bee5-0e5cb1f51dad">
+        <name>Germany</name>
+        <sort-name>Germany</sort-name>
+    </area>
+    <life-span>
+        <begin>1898</begin>
+        <ended>false</ended>
+    </life-span>
+    <alias-list>
+        <alias sort-name="Deutsche Grammaphon">Deutsche Grammaphon</alias>
+        <alias sort-name="Deutsche Grammophone">Deutsche Grammophone</alias>
+        <alias sort-name="Deutsche Grammophon Gesellschaft">Deutsche Grammophon Gesellschaft</alias>
+        <alias sort-name="Deutsche Grammophon GmbH">Deutsche Grammophon GmbH</alias>
+        <alias sort-name="Deutsche Grammophon (Universal)">Deutsche Grammophon (Universal)</alias>
+        <alias sort-name="Deutsche Gramophon">Deutsche Gramophon</alias>
+        <alias sort-name="DG">DG</alias>
+    </alias-list>
+    <tag-list>
+        <tag count="2">
+            <name>classical</name>
+        </tag>
+        <tag count="1">
+            <name>tomatito</name>
+        </tag>
+        <tag count="1">
+            <name>deutsche grammophon beethoven</name>
+        </tag>
+    </tag-list>
+</label>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/place-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/place-list.xml
@@ -1,1 +1,19 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><place-list count="1" offset="0"><place id="fd60135e-d173-4a56-87fd-1f1c4bc62bd1" type="Venue" ns2:score="100"><name>Ilmbühne</name><coordinates><latitude>50.99508</latitude><longitude>11.36062</longitude></coordinates><area id="c7644e45-dec4-43fd-aad6-35036b8e911d"><name>Weimar</name><sort-name>Weimar</sort-name></area><alias-list><alias sort-name="Lindenrondell" type="Search hint">Lindenrondell</alias></alias-list></place></place-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <place-list count="1" offset="0">
+        <place id="fd60135e-d173-4a56-87fd-1f1c4bc62bd1" type="Venue" ns2:score="100">
+            <name>Ilmbühne</name>
+            <coordinates>
+                <latitude>50.99508</latitude>
+                <longitude>11.36062</longitude>
+            </coordinates>
+            <area id="c7644e45-dec4-43fd-aad6-35036b8e911d">
+                <name>Weimar</name>
+                <sort-name>Weimar</sort-name>
+            </area>
+            <alias-list>
+                <alias sort-name="Lindenrondell" type="Search hint">Lindenrondell</alias>
+            </alias-list>
+        </place>
+    </place-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/place.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/place.xml
@@ -1,1 +1,14 @@
-<place xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="fd60135e-d173-4a56-87fd-1f1c4bc62bd1" type="Venue"><name>Ilmbühne</name><coordinates><latitude>50.99508</latitude><longitude>11.36062</longitude></coordinates><area id="c7644e45-dec4-43fd-aad6-35036b8e911d"><name>Weimar</name><sort-name>Weimar</sort-name></area><alias-list><alias sort-name="Lindenrondell" type="Search hint">Lindenrondell</alias></alias-list></place>
+<place xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="fd60135e-d173-4a56-87fd-1f1c4bc62bd1" type="Venue">
+    <name>Ilmbühne</name>
+    <coordinates>
+        <latitude>50.99508</latitude>
+        <longitude>11.36062</longitude>
+    </coordinates>
+    <area id="c7644e45-dec4-43fd-aad6-35036b8e911d">
+        <name>Weimar</name>
+        <sort-name>Weimar</sort-name>
+    </area>
+    <alias-list>
+        <alias sort-name="Lindenrondell" type="Search hint">Lindenrondell</alias>
+    </alias-list>
+</place>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
@@ -1,1 +1,110 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><recording-list count="1" offset="0"><recording id="3e0bdde6-74e0-46d4-855a-4493589fd6b2" ns2:score="100"><title>Roots and Beginnings</title><length>391000</length><artist-credit><name-credit><artist id="9b58672a-e68e-4972-956e-a8985a165a1f"><name>Howard Shore</name><sort-name>Shore, Howard</sort-name><alias-list><alias sort-name="Howard Shaw">Howard Shaw</alias><alias sort-name="H. Shore">H. Shore</alias><alias sort-name="Shore">Shore</alias></alias-list></artist></name-credit></artist-credit><release-list><release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49"><title>The Lord of the Rings: The Return of the King: The Complete Recordings</title><status>Official</status><release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack"><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type><secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type></secondary-type-list></release-group><date>2007-11-20</date><country>US</country><release-event-list><release-event><date>2007-11-20</date><area id="489ce91b-6658-3307-9877-795b68554c98"><name>United States</name><sort-name>United States</sort-name><iso-3166-1-code-list><iso-3166-1-code>US</iso-3166-1-code></iso-3166-1-code-list></area></release-event></release-event-list><medium-list><track-count>106</track-count><medium><position>1</position><format>CD</format><track-list count="15" offset="0"><track id="fc51bf50-c329-3d93-bb1b-e4f55cf00db8"><number>1</number><title>Roots and Beginnings</title><length>391000</length></track></track-list></medium></medium-list></release><release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49"><title>The Lord of the Rings: The Return of the King: The Complete Recordings</title><status>Official</status><release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack"><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type><secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type></secondary-type-list></release-group><date>2007-11-20</date><country>US</country><release-event-list><release-event><date>2007-11-20</date><area id="489ce91b-6658-3307-9877-795b68554c98"><name>United States</name><sort-name>United States</sort-name><iso-3166-1-code-list><iso-3166-1-code>US</iso-3166-1-code></iso-3166-1-code-list></area></release-event></release-event-list><medium-list><track-count>106</track-count><medium><position>5</position><format>DVD</format><track-list count="53" offset="0"><track id="af77973d-3ca5-38e3-89ff-c742c94f59af"><number>1</number><title>Roots and Beginnings</title><length>391000</length></track></track-list></medium></medium-list></release></release-list><isrc-list><isrc id="USRE10701410"/></isrc-list><tag-list><tag count="2"><name>soundtrack</name></tag></tag-list></recording></recording-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <recording-list count="1" offset="0">
+        <recording id="3e0bdde6-74e0-46d4-855a-4493589fd6b2" ns2:score="100">
+            <title>Roots and Beginnings</title>
+            <length>391000</length>
+            <artist-credit>
+                <name-credit>
+                    <artist id="9b58672a-e68e-4972-956e-a8985a165a1f">
+                        <name>Howard Shore</name>
+                        <sort-name>Shore, Howard</sort-name>
+                        <alias-list>
+                            <alias sort-name="Howard Shaw">Howard Shaw</alias>
+                            <alias sort-name="H. Shore">H. Shore</alias>
+                            <alias sort-name="Shore">Shore</alias>
+                        </alias-list>
+                    </artist>
+                </name-credit>
+            </artist-credit>
+            <release-list>
+                <release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49">
+                    <title>The Lord of the Rings: The Return of the King: The Complete Recordings</title>
+                    <status>Official</status>
+                    <release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack">
+                        <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+                        <secondary-type-list>
+                            <secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type>
+                            <secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type>
+                        </secondary-type-list>
+                    </release-group>
+                    <date>2007-11-20</date>
+                    <country>US</country>
+                    <release-event-list>
+                        <release-event>
+                            <date>2007-11-20</date>
+                            <area id="489ce91b-6658-3307-9877-795b68554c98">
+                                <name>United States</name>
+                                <sort-name>United States</sort-name>
+                                <iso-3166-1-code-list>
+                                    <iso-3166-1-code>US</iso-3166-1-code>
+                                </iso-3166-1-code-list>
+                            </area>
+                        </release-event>
+                    </release-event-list>
+                    <medium-list>
+                        <track-count>106</track-count>
+                        <medium>
+                            <position>1</position>
+                            <format>CD</format>
+                            <track-list count="15" offset="0">
+                                <track id="fc51bf50-c329-3d93-bb1b-e4f55cf00db8">
+                                    <number>1</number>
+                                    <title>Roots and Beginnings</title>
+                                    <length>391000</length>
+                                </track>
+                            </track-list>
+                        </medium>
+                    </medium-list>
+                </release>
+                <release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49">
+                    <title>The Lord of the Rings: The Return of the King: The Complete Recordings</title>
+                    <status>Official</status>
+                    <release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack">
+                        <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+                        <secondary-type-list>
+                            <secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type>
+                            <secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type>
+                        </secondary-type-list>
+                    </release-group>
+                    <date>2007-11-20</date>
+                    <country>US</country>
+                    <release-event-list>
+                        <release-event>
+                            <date>2007-11-20</date>
+                            <area id="489ce91b-6658-3307-9877-795b68554c98">
+                                <name>United States</name>
+                                <sort-name>United States</sort-name>
+                                <iso-3166-1-code-list>
+                                    <iso-3166-1-code>US</iso-3166-1-code>
+                                </iso-3166-1-code-list>
+                            </area>
+                        </release-event>
+                    </release-event-list>
+                    <medium-list>
+                        <track-count>106</track-count>
+                        <medium>
+                            <position>5</position>
+                            <format>DVD</format>
+                            <track-list count="53" offset="0">
+                                <track id="af77973d-3ca5-38e3-89ff-c742c94f59af">
+                                    <number>1</number>
+                                    <title>Roots and Beginnings</title>
+                                    <length>391000</length>
+                                </track>
+                            </track-list>
+                        </medium>
+                    </medium-list>
+                </release>
+            </release-list>
+            <isrc-list>
+                <isrc id="USRE10701410"/>
+            </isrc-list>
+            <tag-list>
+                <tag count="2">
+                    <name>soundtrack</name>
+                </tag>
+            </tag-list>
+        </recording>
+    </recording-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
@@ -1,1 +1,105 @@
-<recording xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="3e0bdde6-74e0-46d4-855a-4493589fd6b2"><title>Roots and Beginnings</title><length>391000</length><artist-credit><name-credit><artist id="9b58672a-e68e-4972-956e-a8985a165a1f"><name>Howard Shore</name><sort-name>Shore, Howard</sort-name><alias-list><alias sort-name="Howard Shaw">Howard Shaw</alias><alias sort-name="H. Shore">H. Shore</alias><alias sort-name="Shore">Shore</alias></alias-list></artist></name-credit></artist-credit><release-list><release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49"><title>The Lord of the Rings: The Return of the King: The Complete Recordings</title><status>Official</status><release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack"><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type><secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type></secondary-type-list></release-group><date>2007-11-20</date><country>US</country><release-event-list><release-event><date>2007-11-20</date><area id="489ce91b-6658-3307-9877-795b68554c98"><name>United States</name><sort-name>United States</sort-name><iso-3166-1-code-list><iso-3166-1-code>US</iso-3166-1-code></iso-3166-1-code-list></area></release-event></release-event-list><medium-list><track-count>106</track-count><medium><position>1</position><format>CD</format><track-list count="15" offset="0"><track id="fc51bf50-c329-3d93-bb1b-e4f55cf00db8"><number>1</number><title>Roots and Beginnings</title><length>391000</length></track></track-list></medium></medium-list></release><release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49"><title>The Lord of the Rings: The Return of the King: The Complete Recordings</title><status>Official</status><release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack"><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type><secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type></secondary-type-list></release-group><date>2007-11-20</date><country>US</country><release-event-list><release-event><date>2007-11-20</date><area id="489ce91b-6658-3307-9877-795b68554c98"><name>United States</name><sort-name>United States</sort-name><iso-3166-1-code-list><iso-3166-1-code>US</iso-3166-1-code></iso-3166-1-code-list></area></release-event></release-event-list><medium-list><track-count>106</track-count><medium><position>5</position><format>DVD</format><track-list count="53" offset="0"><track id="af77973d-3ca5-38e3-89ff-c742c94f59af"><number>1</number><title>Roots and Beginnings</title><length>391000</length></track></track-list></medium></medium-list></release></release-list><isrc-list><isrc id="USRE10701410"/></isrc-list><tag-list><tag count="2"><name>soundtrack</name></tag></tag-list></recording>
+<recording xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="3e0bdde6-74e0-46d4-855a-4493589fd6b2">
+    <title>Roots and Beginnings</title>
+    <length>391000</length>
+    <artist-credit>
+        <name-credit>
+            <artist id="9b58672a-e68e-4972-956e-a8985a165a1f">
+                <name>Howard Shore</name>
+                <sort-name>Shore, Howard</sort-name>
+                <alias-list>
+                    <alias sort-name="Howard Shaw">Howard Shaw</alias>
+                    <alias sort-name="H. Shore">H. Shore</alias>
+                    <alias sort-name="Shore">Shore</alias>
+                </alias-list>
+            </artist>
+        </name-credit>
+    </artist-credit>
+    <release-list>
+        <release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49">
+            <title>The Lord of the Rings: The Return of the King: The Complete Recordings</title>
+            <status>Official</status>
+            <release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack">
+                <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+                <secondary-type-list>
+                    <secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type>
+                    <secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type>
+                </secondary-type-list>
+            </release-group>
+            <date>2007-11-20</date>
+            <country>US</country>
+            <release-event-list>
+                <release-event>
+                    <date>2007-11-20</date>
+                    <area id="489ce91b-6658-3307-9877-795b68554c98">
+                        <name>United States</name>
+                        <sort-name>United States</sort-name>
+                        <iso-3166-1-code-list>
+                            <iso-3166-1-code>US</iso-3166-1-code>
+                        </iso-3166-1-code-list>
+                    </area>
+                </release-event>
+            </release-event-list>
+            <medium-list>
+                <track-count>106</track-count>
+                <medium>
+                    <position>1</position>
+                    <format>CD</format>
+                    <track-list count="15" offset="0">
+                        <track id="fc51bf50-c329-3d93-bb1b-e4f55cf00db8">
+                            <number>1</number>
+                            <title>Roots and Beginnings</title>
+                            <length>391000</length>
+                        </track>
+                    </track-list>
+                </medium>
+            </medium-list>
+        </release>
+        <release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49">
+            <title>The Lord of the Rings: The Return of the King: The Complete Recordings</title>
+            <status>Official</status>
+            <release-group id="f5fd971c-a1a2-33da-95b0-473e0176df83" type="Soundtrack">
+                <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+                <secondary-type-list>
+                    <secondary-type id="22a628ad-c082-3c4f-b1b6-d41665107b88">Soundtrack</secondary-type>
+                    <secondary-type id="6fd474e2-6b58-3102-9d17-d6f7eb7da0a0">Live</secondary-type>
+                </secondary-type-list>
+            </release-group>
+            <date>2007-11-20</date>
+            <country>US</country>
+            <release-event-list>
+                <release-event>
+                    <date>2007-11-20</date>
+                    <area id="489ce91b-6658-3307-9877-795b68554c98">
+                        <name>United States</name>
+                        <sort-name>United States</sort-name>
+                        <iso-3166-1-code-list>
+                            <iso-3166-1-code>US</iso-3166-1-code>
+                        </iso-3166-1-code-list>
+                    </area>
+                </release-event>
+            </release-event-list>
+            <medium-list>
+                <track-count>106</track-count>
+                <medium>
+                    <position>5</position>
+                    <format>DVD</format>
+                    <track-list count="53" offset="0">
+                        <track id="af77973d-3ca5-38e3-89ff-c742c94f59af">
+                            <number>1</number>
+                            <title>Roots and Beginnings</title>
+                            <length>391000</length>
+                        </track>
+                    </track-list>
+                </medium>
+            </medium-list>
+        </release>
+    </release-list>
+    <isrc-list>
+        <isrc id="USRE10701410"/>
+    </isrc-list>
+    <tag-list>
+        <tag count="2">
+            <name>soundtrack</name>
+        </tag>
+    </tag-list>
+</recording>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.xml
@@ -1,1 +1,32 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata  xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><release-group-list count="1" offset="0"><release-group id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation" ns2:score="100"><title>Chiptunes = WIN \m|♥|m/</title><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type></secondary-type-list><artist-credit><name-credit><artist id="89ad4ac3-39f7-470e-963a-56509c546377"><name>Various Artists</name><sort-name>Various Artists</sort-name><disambiguation>add compilations to this artist</disambiguation></artist></name-credit></artist-credit><release-list count="1"><release id="871f12ec-6259-4e93-b440-9108559c38b1"><title>Chiptunes = WIN \m|♥|m/</title><status>Official</status></release></release-list><tag-list><tag count="1"><name>electronic</name></tag></tag-list></release-group></release-group-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <release-group-list count="1" offset="0">
+        <release-group id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation" ns2:score="100">
+            <title>Chiptunes = WIN \m|♥|m/</title>
+            <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+            <secondary-type-list>
+                <secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type>
+            </secondary-type-list>
+            <artist-credit>
+                <name-credit>
+                    <artist id="89ad4ac3-39f7-470e-963a-56509c546377">
+                        <name>Various Artists</name>
+                        <sort-name>Various Artists</sort-name>
+                        <disambiguation>add compilations to this artist</disambiguation>
+                    </artist>
+                </name-credit>
+            </artist-credit>
+            <release-list count="1">
+                <release id="871f12ec-6259-4e93-b440-9108559c38b1">
+                    <title>Chiptunes = WIN \m|♥|m/</title>
+                    <status>Official</status>
+                </release>
+            </release-list>
+            <tag-list>
+                <tag count="1">
+                    <name>electronic</name>
+                </tag>
+            </tag-list>
+        </release-group>
+    </release-group-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group.xml
@@ -1,1 +1,27 @@
-<release-group xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation"><title>Chiptunes = WIN \m|♥|m/</title><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type></secondary-type-list><artist-credit><name-credit><artist id="89ad4ac3-39f7-470e-963a-56509c546377"><name>Various Artists</name><sort-name>Various Artists</sort-name><disambiguation>add compilations to this artist</disambiguation></artist></name-credit></artist-credit><release-list count="1"><release id="871f12ec-6259-4e93-b440-9108559c38b1"><title>Chiptunes = WIN \m|♥|m/</title><status>Official</status></release></release-list><tag-list><tag count="1"><name>electronic</name></tag></tag-list></release-group>
+<release-group xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation">
+    <title>Chiptunes = WIN \m|♥|m/</title>
+    <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+    <secondary-type-list>
+        <secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type>
+    </secondary-type-list>
+    <artist-credit>
+        <name-credit>
+            <artist id="89ad4ac3-39f7-470e-963a-56509c546377">
+                <name>Various Artists</name>
+                <sort-name>Various Artists</sort-name>
+                <disambiguation>add compilations to this artist</disambiguation>
+            </artist>
+        </name-credit>
+    </artist-credit>
+    <release-list count="1">
+        <release id="871f12ec-6259-4e93-b440-9108559c38b1">
+            <title>Chiptunes = WIN \m|♥|m/</title>
+            <status>Official</status>
+        </release>
+    </release-list>
+    <tag-list>
+        <tag count="1">
+            <name>electronic</name>
+        </tag>
+    </tag-list>
+</release-group>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.xml
@@ -1,1 +1,72 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><release-list count="1" offset="0"><release id="871f12ec-6259-4e93-b440-9108559c38b1" ns2:score="100"><title>Chiptunes = WIN \m|♥|m/</title><status>Official</status><packaging id="119eba76-b343-3e02-a292-f0f00644bb9b">None</packaging><text-representation><language>eng</language><script>Latn</script></text-representation><artist-credit><name-credit><artist id="2b542c4a-694a-49b9-b475-9f55f99436a1"><name>Chiptunes = WIN \m|♥|m/</name><sort-name>Chiptunes = WIN \m|♥|m/</sort-name><alias-list><alias sort-name="Chiptunes = WIN">Chiptunes = WIN</alias></alias-list></artist></name-credit></artist-credit><release-group id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation"><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type></secondary-type-list></release-group><date>2012-06-05</date><country>XW</country><release-event-list><release-event><date>2012-06-05</date><area id="525d4e18-3d00-31b9-a58b-a146a916de8f"><name>[Worldwide]</name><sort-name>[Worldwide]</sort-name><iso-3166-1-code-list><iso-3166-1-code>XW</iso-3166-1-code></iso-3166-1-code-list></area></release-event></release-event-list><barcode/><label-info-list><label-info><label id="7669cf9a-7328-44cf-96ba-b2dc9d534ed8"><name>Chiptunes = WIN \m|♥|m/</name></label></label-info></label-info-list><medium-list count="1"><track-count>51</track-count><medium><format>Digital Media</format><disc-list count="0"/><track-list count="51"/></medium></medium-list><tag-list><tag count="1"><name>bitunes</name></tag><tag count="1"><name>bandcamp</name></tag><tag count="2"><name>chiptunes</name></tag></tag-list></release></release-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <release-list count="1" offset="0">
+        <release id="871f12ec-6259-4e93-b440-9108559c38b1" ns2:score="100">
+            <title>Chiptunes = WIN \m|♥|m/</title>
+            <status>Official</status>
+            <packaging id="119eba76-b343-3e02-a292-f0f00644bb9b">None</packaging>
+            <text-representation>
+                <language>eng</language>
+                <script>Latn</script>
+            </text-representation>
+            <artist-credit>
+                <name-credit>
+                    <artist id="2b542c4a-694a-49b9-b475-9f55f99436a1">
+                        <name>Chiptunes = WIN \m|♥|m/</name>
+                        <sort-name>Chiptunes = WIN \m|♥|m/</sort-name>
+                        <alias-list>
+                            <alias sort-name="Chiptunes = WIN">Chiptunes = WIN</alias>
+                        </alias-list>
+                    </artist>
+                </name-credit>
+            </artist-credit>
+            <release-group id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation">
+                <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+                <secondary-type-list>
+                    <secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type>
+                </secondary-type-list>
+            </release-group>
+            <date>2012-06-05</date>
+            <country>XW</country>
+            <release-event-list>
+                <release-event>
+                    <date>2012-06-05</date>
+                    <area id="525d4e18-3d00-31b9-a58b-a146a916de8f">
+                        <name>[Worldwide]</name>
+                        <sort-name>[Worldwide]</sort-name>
+                        <iso-3166-1-code-list>
+                            <iso-3166-1-code>XW</iso-3166-1-code>
+                        </iso-3166-1-code-list>
+                    </area>
+                </release-event>
+            </release-event-list>
+            <barcode/>
+            <label-info-list>
+                <label-info>
+                    <label id="7669cf9a-7328-44cf-96ba-b2dc9d534ed8">
+                        <name>Chiptunes = WIN \m|♥|m/</name>
+                    </label>
+                </label-info>
+            </label-info-list>
+            <medium-list count="1">
+                <track-count>51</track-count>
+                <medium>
+                    <format>Digital Media</format>
+                    <disc-list count="0"/>
+                    <track-list count="51"/>
+                </medium>
+            </medium-list>
+            <tag-list>
+                <tag count="1">
+                    <name>bitunes</name>
+                </tag>
+                <tag count="1">
+                    <name>bandcamp</name>
+                </tag>
+                <tag count="2">
+                    <name>chiptunes</name>
+                </tag>
+            </tag-list>
+        </release>
+    </release-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release.xml
@@ -1,1 +1,67 @@
-<release xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="871f12ec-6259-4e93-b440-9108559c38b1"><title>Chiptunes = WIN \m|♥|m/</title><status>Official</status><packaging id="119eba76-b343-3e02-a292-f0f00644bb9b">None</packaging><text-representation><language>eng</language><script>Latn</script></text-representation><artist-credit><name-credit><artist id="2b542c4a-694a-49b9-b475-9f55f99436a1"><name>Chiptunes = WIN \m|♥|m/</name><sort-name>Chiptunes = WIN \m|♥|m/</sort-name><alias-list><alias sort-name="Chiptunes = WIN">Chiptunes = WIN</alias></alias-list></artist></name-credit></artist-credit><release-group id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation"><primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type><secondary-type-list><secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type></secondary-type-list></release-group><date>2012-06-05</date><country>XW</country><release-event-list><release-event><date>2012-06-05</date><area id="525d4e18-3d00-31b9-a58b-a146a916de8f"><name>[Worldwide]</name><sort-name>[Worldwide]</sort-name><iso-3166-1-code-list><iso-3166-1-code>XW</iso-3166-1-code></iso-3166-1-code-list></area></release-event></release-event-list><barcode/><label-info-list><label-info><label id="7669cf9a-7328-44cf-96ba-b2dc9d534ed8"><name>Chiptunes = WIN \m|♥|m/</name></label></label-info></label-info-list><medium-list count="1"><track-count>51</track-count><medium><format>Digital Media</format><disc-list count="0"/><track-list count="51"/></medium></medium-list><tag-list><tag count="1"><name>bitunes</name></tag><tag count="1"><name>bandcamp</name></tag><tag count="2"><name>chiptunes</name></tag></tag-list></release>
+<release xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="871f12ec-6259-4e93-b440-9108559c38b1">
+    <title>Chiptunes = WIN \m|♥|m/</title>
+    <status>Official</status>
+    <packaging id="119eba76-b343-3e02-a292-f0f00644bb9b">None</packaging>
+    <text-representation>
+        <language>eng</language>
+        <script>Latn</script>
+    </text-representation>
+    <artist-credit>
+        <name-credit>
+            <artist id="2b542c4a-694a-49b9-b475-9f55f99436a1">
+                <name>Chiptunes = WIN \m|♥|m/</name>
+                <sort-name>Chiptunes = WIN \m|♥|m/</sort-name>
+                <alias-list>
+                    <alias sort-name="Chiptunes = WIN">Chiptunes = WIN</alias>
+                </alias-list>
+            </artist>
+        </name-credit>
+    </artist-credit>
+    <release-group id="268d91a0-1a7f-4600-bfd4-74d738eb7de4" type="Compilation">
+        <primary-type id="f529b476-6e62-324f-b0aa-1f3e33d313fc">Album</primary-type>
+        <secondary-type-list>
+            <secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type>
+        </secondary-type-list>
+    </release-group>
+    <date>2012-06-05</date>
+    <country>XW</country>
+    <release-event-list>
+        <release-event>
+            <date>2012-06-05</date>
+            <area id="525d4e18-3d00-31b9-a58b-a146a916de8f">
+                <name>[Worldwide]</name>
+                <sort-name>[Worldwide]</sort-name>
+                <iso-3166-1-code-list>
+                    <iso-3166-1-code>XW</iso-3166-1-code>
+                </iso-3166-1-code-list>
+            </area>
+        </release-event>
+    </release-event-list>
+    <barcode/>
+    <label-info-list>
+        <label-info>
+            <label id="7669cf9a-7328-44cf-96ba-b2dc9d534ed8">
+                <name>Chiptunes = WIN \m|♥|m/</name>
+            </label>
+        </label-info>
+    </label-info-list>
+    <medium-list count="1">
+        <track-count>51</track-count>
+        <medium>
+            <format>Digital Media</format>
+            <disc-list count="0"/>
+            <track-list count="51"/>
+        </medium>
+    </medium-list>
+    <tag-list>
+        <tag count="1">
+            <name>bitunes</name>
+        </tag>
+        <tag count="1">
+            <name>bandcamp</name>
+        </tag>
+        <tag count="2">
+            <name>chiptunes</name>
+        </tag>
+    </tag-list>
+</release>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/series-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/series-list.xml
@@ -1,1 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?> <metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0"><series-list count="1" offset="0"><series id="d271a712-90a9-43fb-9470-3151ebb9389a" type="Release" ns2:score="100"><name>The World Roots Music Library</name><disambiguation>2008</disambiguation><alias-list><alias locale="ja" sort-name="ザ・ワールド・ルーツ・ミュージック・ライブラリー" type="Series name" primary="primary">ザ・ワールド・ルーツ・ミュージック・ライブラリー</alias><alias locale="en" sort-name="World Roots Music Library, The" type="Series name" primary="primary">The World Roots Music Library</alias></alias-list></series></series-list></metadata>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+    <series-list count="1" offset="0">
+        <series id="d271a712-90a9-43fb-9470-3151ebb9389a" type="Release" ns2:score="100">
+            <name>The World Roots Music Library</name>
+            <disambiguation>2008</disambiguation>
+            <alias-list>
+                <alias locale="ja" sort-name="ザ・ワールド・ルーツ・ミュージック・ライブラリー" type="Series name" primary="primary">ザ・ワールド・ルーツ・ミュージック・ライブラリー</alias>
+                <alias locale="en" sort-name="World Roots Music Library, The" type="Series name" primary="primary">The World Roots Music Library</alias>
+            </alias-list>
+        </series>
+    </series-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/series.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/series.xml
@@ -1,1 +1,8 @@
-<series xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="d271a712-90a9-43fb-9470-3151ebb9389a" type="Release"><name>The World Roots Music Library</name><disambiguation>2008</disambiguation><alias-list><alias locale="ja" sort-name="ザ・ワールド・ルーツ・ミュージック・ライブラリー" type="Series name" primary="primary">ザ・ワールド・ルーツ・ミュージック・ライブラリー</alias><alias locale="en" sort-name="World Roots Music Library, The" type="Series name" primary="primary">The World Roots Music Library</alias></alias-list></series>
+<series xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="d271a712-90a9-43fb-9470-3151ebb9389a" type="Release">
+    <name>The World Roots Music Library</name>
+    <disambiguation>2008</disambiguation>
+    <alias-list>
+        <alias locale="ja" sort-name="ザ・ワールド・ルーツ・ミュージック・ライブラリー" type="Series name" primary="primary">ザ・ワールド・ルーツ・ミュージック・ライブラリー</alias>
+        <alias locale="en" sort-name="World Roots Music Library, The" type="Series name" primary="primary">The World Roots Music Library</alias>
+    </alias-list>
+</series>


### PR DESCRIPTION
This PR involves two kinds of changes. 

The first is to configure the `DiffBuilder` comparing the expected and actual responses to ignore white spaces and newlines outside XML tags. The `Diffbuilder` has also been configured to ignore comments if any in the resource files. Currently, there are no comments. That is probably because having comments in the XML files earlier would result in a failed test. In the future, we can add comments to the XML files to mark for instance schema inconsistencies. 

The second kind of change is to actually reformat the XML resource files to make them easier to read by humans.