### PR TITLE
SEARCH-218 / SEARCH-384 / SEARCH-574 / SEARCH-590 / SEARCH-590: Update mbsssss

### DIFF
--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterRecordingTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterRecordingTest.java
@@ -13,6 +13,7 @@ public abstract class AbstractMBWriterRecordingTest extends AbstractMBWriterTest
 				"artist", "Howard Shore",
 				"artistname", "Howard Shore",
 				"creditname", "Howard Shore",
+				"firstreleasedate", "2007-11-05",
 				"video", "false"
 		}));
 	}

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
@@ -47,6 +47,7 @@
                     }
                 }
             ],
+            "first-release-date": "2007-11-05",
             "releases": [
                 {
                     "id": "e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49",

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
@@ -17,6 +17,7 @@
                     </artist>
                 </name-credit>
             </artist-credit>
+            <first-release-date>2007-11-05</first-release-date>
             <release-list>
                 <release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49">
                     <title>The Lord of the Rings: The Return of the King: The Complete Recordings</title>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
@@ -14,6 +14,7 @@
             </artist>
         </name-credit>
     </artist-credit>
+    <first-release-date>2007-11-05</first-release-date>
     <release-list>
         <release id="e7fe61ca-65b8-4abb-8723-1e7c1a5e0a49">
             <title>The Lord of the Rings: The Return of the King: The Complete Recordings</title>


### PR DESCRIPTION
# Problems

SEARCH-218: Add first release date to the fields and results of indexed search for recordings

But also:

SEARCH-384: Add first release date to the fields of indexed search for release-groups
SEARCH-574: Make release’s format search field insensitive to spaces and separators
SEARCH-590: Add packaging to the fields of indexed search for releases

# Solution

* Update `mbsssss` to [`v-2020-12-24`](https://github.com/metabrainz/mbsssss/releases/tag/v-2020-12-24) which features:
  * metabrainz/mbsssss#54 for SEARCH-218 (recording’s first release date) and SEARCH-384 (RG’s first release date)
  * metabrainz/mbsssss#55 for SEARCH-590 (release’s packaging)
  * metabrainz/mbsssss#56 for SEARCH-574 (release’s medium format improvement)
* Update tests according to SEARCH-218 (even though it is not strictly needed as first-release-date is optional)

# Checklist for author

* [x] Check documentation: to be updated with the corresponding SIR updates.
* [x] Merge related PRs metabrainz/sir#102, metabrainz/sir#114, and metabrainz/sir#115 too.

# Action

1. Release SIR changes at the same time.
2. Make updated WikiDocs pages visible on MusicBrainz website:
   * https://musicbrainz.org/doc/Indexed_Search_Syntax (changes made to included subpages, see SIR PRs)
   * https://musicbrainz.org/doc/MusicBrainz_API/Search (changes made to included subpages, see SIR PRs)