### PR TITLE
Mitigation for CVE-2021-44228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,3 +66,6 @@ RUN sed -i'' 's|</solr>|<str name="sharedLib">/opt/solr/lib</str></solr>|' \
     chown -R solr:solr /opt/solr
 
 USER $SOLR_USER
+
+# Mitigation for CVE-2021-44228
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS true

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ A branch of the MusicBrainz server that can query a Solr server with this
 QueryResponseWriter is available on
 [GitHub](https://github.com/mineo/musicbrainz-server/tree/solr-search).
 
+### Known Vulnerabilities
+
+- [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228):
+  It can be mitigated by setting the environement variable `LOG4J_FORMAT_MSG_NO_LOOKUPS=true`.
+
 ## Docker Installation
 
 Clone the repository with Git:


### PR DESCRIPTION
MB Solr is currently affected by [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228). This patch:
- Mitigate the issue when building Docker images;
- Explain mitigating the issue when installing without Docker.