### PR TITLE
SEARCH-690 (writer): Add artist credit MBID to output 

### DIFF
--- a/mb-solr/src/main/resources/oxml.xml
+++ b/mb-solr/src/main/resources/oxml.xml
@@ -218,6 +218,7 @@
         </java-type>
         <java-type name="ArtistCredit">
             <java-attributes>
+                <xml-attribute java-attribute="id" name="artist-credit-id"/>
                 <xml-element java-attribute="nameCredit" name="artist-credit"/>
             </java-attributes>
         </java-type>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
@@ -47,6 +47,7 @@
                     }
                 }
             ],
+            "artist-credit-id": "aca3f13c-7e5d-3f4c-8cf8-97a4cd2cf9d4",
             "first-release-date": "2007-11-05",
             "releases": [
                 {

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
@@ -4,7 +4,7 @@
         <recording id="3e0bdde6-74e0-46d4-855a-4493589fd6b2" ns2:score="100">
             <title>Roots and Beginnings</title>
             <length>391000</length>
-            <artist-credit>
+            <artist-credit id="aca3f13c-7e5d-3f4c-8cf8-97a4cd2cf9d4">
                 <name-credit>
                     <artist id="9b58672a-e68e-4972-956e-a8985a165a1f">
                         <name>Howard Shore</name>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
@@ -1,7 +1,7 @@
 <recording xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="3e0bdde6-74e0-46d4-855a-4493589fd6b2">
     <title>Roots and Beginnings</title>
     <length>391000</length>
-    <artist-credit>
+    <artist-credit id="aca3f13c-7e5d-3f4c-8cf8-97a4cd2cf9d4">
         <name-credit>
             <artist id="9b58672a-e68e-4972-956e-a8985a165a1f">
                 <name>Howard Shore</name>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.json
@@ -26,6 +26,7 @@
                     }
                 }
             ],
+            "artist-credit-id": "8d24c5da-ac9d-3a77-866b-91c7e2177ede",
             "releases": [
                 {
                     "id": "871f12ec-6259-4e93-b440-9108559c38b1",

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group-list.xml
@@ -7,7 +7,7 @@
             <secondary-type-list>
                 <secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type>
             </secondary-type-list>
-            <artist-credit>
+            <artist-credit id="8d24c5da-ac9d-3a77-866b-91c7e2177ede">
                 <name-credit>
                     <artist id="89ad4ac3-39f7-470e-963a-56509c546377">
                         <name>Various Artists</name>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-group.xml
@@ -4,7 +4,7 @@
     <secondary-type-list>
         <secondary-type id="dd2a21e1-0c00-3729-a7a0-de60b84eb5d1">Compilation</secondary-type>
     </secondary-type-list>
-    <artist-credit>
+    <artist-credit id="8d24c5da-ac9d-3a77-866b-91c7e2177ede">
         <name-credit>
             <artist id="89ad4ac3-39f7-470e-963a-56509c546377">
                 <name>Various Artists</name>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.json
@@ -36,6 +36,7 @@
                     }
                 }
             ],
+            "artist-credit-id": "8d24c5da-ac9d-3a77-866b-91c7e2177ede",
             "release-group": {
                 "id": "268d91a0-1a7f-4600-bfd4-74d738eb7de4",
                 "primary-type": "Album",

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.xml
@@ -9,7 +9,7 @@
                 <language>eng</language>
                 <script>Latn</script>
             </text-representation>
-            <artist-credit>
+            <artist-credit id="8d24c5da-ac9d-3a77-866b-91c7e2177ede">
                 <name-credit>
                     <artist id="2b542c4a-694a-49b9-b475-9f55f99436a1">
                         <name>Chiptunes = WIN \m|♥|m/</name>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release.xml
@@ -6,7 +6,7 @@
         <language>eng</language>
         <script>Latn</script>
     </text-representation>
-    <artist-credit>
+    <artist-credit id="8d24c5da-ac9d-3a77-866b-91c7e2177ede">
         <name-credit>
             <artist id="2b542c4a-694a-49b9-b475-9f55f99436a1">
                 <name>Chiptunes = WIN \m|♥|m/</name>


### PR DESCRIPTION
# Problem: SEARCH-690 (writer part)

Search server doesn’t include MBID in results for search indexes (recording, release, release-group) that have artist credit.


# Solution

* Switch `mmd-schema` used to write the results to an (upcoming) version that includes artist credit MBID;
* Add `id` attribute to `artist-credit` XML element.
* Update XML and JSON tests accordingly


# Todolist before merging
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [X] Test it locally with unreleased `mmd-schema` version; See https://github.com/metabrainz/sir/pull/157
* [x] Have a new release of [`mmd-schema`](https://github.com/metabrainz/mmd-schema)
* [x] Use that release instead of the unreleased version in git submodule
* [x] Test locally with that release
* [x] Update the [MusicBrainz API Search](https://wiki.musicbrainz.org/MusicBrainz_API/Search) examples in XML and JSON

# Action after merging
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Release and deploy
2. After rebuilding indexes with <https://github.com/metabrainz/sir/pull/157>,
   make the updated WikiDocs page visible on MusicBrainz website