### PR TITLE
SEARCH-625 (MB Solr): Upgrade Java SE version to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- openjdk8
+- openjdk11
 cache:
   directories:
   - "$HOME/.m2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_TAG=3.9.6-eclipse-temurin-8
+ARG MAVEN_TAG=3.9.6-eclipse-temurin-11
 ARG SOLR_NAME=metabrainz/solr
 ARG SOLR_TAG=7.7.2-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_TAG=3.6.1-jdk-8
+ARG MAVEN_TAG=3.9.6-eclipse-temurin-8
 ARG SOLR_NAME=metabrainz/solr
 ARG SOLR_TAG=7.7.2-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG MAVEN_TAG=3.9.6-eclipse-temurin-11
-ARG SOLR_NAME=metabrainz/solr
-ARG SOLR_TAG=7.7.2-alpine
+ARG SOLR_NAME=solr
+ARG SOLR_TAG=7.7.2-slim
 
 FROM maven:${MAVEN_TAG} AS builder
 
@@ -44,12 +44,12 @@ LABEL org.label-schema.build-date="${BUILD_DATE}" \
 # Resetting value set in the parent image
 USER root
 
-RUN apk update && \
-    apk add --no-cache \
+RUN apt-get update && \
+    apt-get install --no-install-recommends \
         # Needed to decompress search index dumps
         zstd \
         && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder \
      mb-solr/target/mb-solr-0.0.1-SNAPSHOT-jar-with-dependencies.jar \

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -59,7 +59,13 @@
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>2.3.0</version>
+			<version>2.3.3</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>2.3.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.concurrentlinkedhashmap</groupId>
@@ -181,8 +187,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.12.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -20,6 +20,11 @@
 			<releases><enabled>false</enabled></releases>
 			<snapshots><enabled>true</enabled></snapshots>
 		</repository>
+		<repository>
+			<id>maven-restlet</id>
+			<name>Restlet repository</name>
+			<url>https://maven.restlet.talend.com</url>
+		</repository>
 	</repositories>
 
 	<dependencies>

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -132,7 +132,7 @@
 			<plugin>
 				<groupId>de.jflex</groupId>
 				<artifactId>jflex-maven-plugin</artifactId>
-				<version>1.6.1</version>
+				<version>1.9.1</version>
 				<executions>
 					<execution>
 						<goals>
@@ -150,7 +150,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.5.5</version>
+				<version>3.6.0</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
@@ -169,17 +169,17 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.3.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>3.2.5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.12.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -188,7 +188,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>versions-maven-plugin</artifactId>
-				<version>2.2</version>
+				<version>2.16.2</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/MBXMLWriter.java
+++ b/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/MBXMLWriter.java
@@ -293,12 +293,20 @@ public class MBXMLWriter implements QueryResponseWriter {
 	}
 
 	public void init(NamedList initArgs) {
+		// JAXB uses context class loader to locate the JAXBContextFactory but Solr's shared
+		// library path is not present in the context class loader. So we need to set the
+		// context class loader to the class loader that loaded our plugin. The JAXB implementation
+		// classes are located in the same jar as this class.
+		ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
 		try {
+			Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
 			context = createJAXBContext();
 			errorContext = createJAXBErrorContext();
 			errorMarshaller = createErrorMarshaller();
 		} catch (JAXBException e) {
 			throw new RuntimeException(e);
+		} finally {
+			Thread.currentThread().setContextClassLoader(originalClassLoader);
 		}
 
 		/*

--- a/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/NotUnmarshallableXmlAdapter.java
+++ b/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/NotUnmarshallableXmlAdapter.java
@@ -7,7 +7,7 @@ public abstract class NotUnmarshallableXmlAdapter<T1, T2> extends XmlAdapter<T1,
     Not used in Search Server
      */
     @Override
-    public T2 unmarshal(T1 _) throws Exception {
+    public T2 unmarshal(T1 t) throws Exception {
         throw new UnsupportedOperationException("Unmarshalling json back to model is not supported");
     }
 }


### PR DESCRIPTION
# SEARCH-625

Java SE 8 isn’t be supported anymore by recent versions of Solr. Upgrading to Java SE 11 is a first big step because of the many changes that occurred with the transfer of Java EE from Oracle to the (Oracle-sponsored) Eclipse Foundation.

It follows the pull request https://github.com/metabrainz/mmd-schema/pull/32 for the Git submodule `mmd-schema`.

See commit messages for details and references.

This pull request partly reuses the aborted draft #38.