### PR TITLE
Upgrade Solr version to 9.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN --mount=type=cache,target=/root/.m2 \
     cd ../mb-solr && \
     mvn package -DskipTests
 
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn dependency:get -Dartifact=jakarta.activation:jakarta.activation-api:2.1.3 && \
+    cp -a /root/.m2/repository/jakarta/activation/jakarta.activation-api/2.1.3/jakarta.activation-api-2.1.3.jar .
+
 FROM ${SOLR_NAME}:${SOLR_TAG}
 ARG SOLR_TAG
 
@@ -39,6 +43,10 @@ RUN apt-get update && \
         zstd \
         && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder --chown=root:root \
+     jakarta.activation-api-2.1.3.jar \
+     /opt/solr/server/lib/ext
 
 COPY --from=builder --chown=solr:solr \
      mb-solr/target/mb-solr-0.0.1-SNAPSHOT-jar-with-dependencies.jar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG MAVEN_TAG=3.9.6-eclipse-temurin-17
 ARG SOLR_NAME=solr
-ARG SOLR_TAG=9.4.0-slim
+ARG SOLR_TAG=9.5.0-slim
 
 FROM maven:${MAVEN_TAG} AS builder
 

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-core</artifactId>
-			<version>9.0.0</version>
+			<version>9.5.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-analysis-icu</artifactId>
-			<version>9.0.0</version>
+			<version>9.9.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-analysis-extras</artifactId>
-			<version>9.0.0</version>
+			<version>9.5.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -80,19 +80,19 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-test-framework</artifactId>
-			<version>9.0.0</version>
+			<version>9.9.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-test-framework</artifactId>
-			<version>9.0.0</version>
+			<version>9.5.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-core</artifactId>
-			<version>9.0.0</version>
+			<version>9.9.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
While we were testing Solr 9.4.0 for SEARCH-685, Solr 9.5.0 has been released.

It’s still time to upgrade to it before switching to Solr 9 in production.

Reference: https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#solr-9-5