### PR TITLE
 Upgrade Solr version to 9.7.0 and other dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,13 +53,17 @@ COPY --from=builder --chown=solr:solr \
      /opt/solr/lib/
 
 COPY --chown=solr:solr \
-    ./mbsssss/solr.xml \
-    /var/solr/data/solr.xml
+     ./mbsssss \
+     /usr/lib/mbsssss
+
+COPY --chmod=0755 \
+     ./docker/entrypoint-initdb.d/* \
+     /docker-entrypoint-initdb.d/
 
 # Creating directory for seach indexes data
 # with ownership to `solr` user/group,
 # so to be used for mounting volume.
-RUN install -d -g solr -o solr /var/solr/data/data
+RUN install -d -g solr -o solr /var/solr/data
 
 ARG MAVEN_TAG
 ARG SOLR_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG MAVEN_TAG=3.9.6-eclipse-temurin-17
 ARG SOLR_NAME=solr
-ARG SOLR_TAG=9.5.0-slim
+ARG SOLR_TAG=9.5.0
 
 FROM maven:${MAVEN_TAG} AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG MAVEN_TAG=3.9.6-eclipse-temurin-17
 ARG SOLR_NAME=solr
-ARG SOLR_TAG=9.5.0
+ARG SOLR_TAG=9.6.1
 
 FROM maven:${MAVEN_TAG} AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG MAVEN_TAG=3.9.6-eclipse-temurin-17
 ARG SOLR_NAME=solr
-ARG SOLR_TAG=9.6.1
+ARG SOLR_TAG=9.7.0
 
 FROM maven:${MAVEN_TAG} AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,14 @@ COPY --chown=solr:solr \
      ./mbsssss \
      /usr/lib/mbsssss
 
+RUN cd /usr/lib/mbsssss && \
+    for conf_dir in */conf; do \
+        core_name="$(dirname "$conf_dir")"; \
+        cd /usr/lib/mbsssss/"$conf_dir" && \
+        zip -r /usr/lib/mbsssss/"$core_name".zip * && \
+        chown solr:solr /usr/lib/mbsssss/"$core_name".zip * || exit 1; \
+    done
+
 COPY --chmod=0755 \
      ./docker/entrypoint-initdb.d/* \
      /docker-entrypoint-initdb.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ COPY --from=builder --chown=solr:solr \
      /opt/solr/lib/
 
 COPY --chown=solr:solr \
-    ./mbsssss \
-    /var/solr/data/mycores/mbsssss
+    ./mbsssss/solr.xml \
+    /var/solr/data/solr.xml
 
 # Creating directory for seach indexes data
 # with ownership to `solr` user/group,

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ USER root
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        # Needed to prepare uploading configsets
+        zip \
         # Needed to decompress search index dumps
         zstd \
         && \
@@ -59,6 +61,10 @@ COPY --chown=solr:solr \
 COPY --chmod=0755 \
      ./docker/entrypoint-initdb.d/* \
      /docker-entrypoint-initdb.d/
+
+COPY --chmod=0755 \
+     ./docker/scripts/* \
+     /opt/solr/docker/scripts/
 
 ARG MAVEN_TAG
 ARG SOLR_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,6 @@ COPY --chmod=0755 \
      ./docker/entrypoint-initdb.d/* \
      /docker-entrypoint-initdb.d/
 
-# Creating directory for seach indexes data
-# with ownership to `solr` user/group,
-# so to be used for mounting volume.
-RUN install -d -g solr -o solr /var/solr/data
-
 ARG MAVEN_TAG
 ARG SOLR_NAME
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,21 @@
+Introduction
+============
+
+The majority of the source code in the mb-solr repository
+is licensed under the below License.
+However, a small number of files are available under a different
+license.
+
+The following files are derived from the Apache Solr project
+licensed under the Apache License 2.0,
+which is included in this file below the License text:
+
+* start-local-solrcloud is derived from start-local-solr
+* start-musicbrainz-solrcloud is derived from start-create
+
+License
+-------
+
 Copyright (c) 2012, Paul Taylor
 Copyright (c) 2014, Wieland Hoffmann
 Copyright (c) 2018, MetaBrainz Foundation
@@ -28,3 +46,207 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+Apache License 2.0
+------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "127.0.0.1:8983:8983"
     volumes:
-      - solr-data:/opt/solr/server/solr/data
+      - solr-data:/var/solr/data/data
 
 volumes:
   solr-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     ports:
       - "127.0.0.1:8983:8983"
     volumes:
-      - solr-data:/var/solr/data/data
+      - solr-data:/var/solr/data/
+    command: solr-foreground --cloud
 
 volumes:
   solr-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "127.0.0.1:8983:8983"
     volumes:
-      - solr-data:/var/solr/data/
+      - solr-data:/var/solr
     command: solr-foreground --cloud
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "127.0.0.1:8983:8983"
     volumes:
       - solr-data:/var/solr
-    command: solr-foreground --cloud
+    command: start-musicbrainz-solrcloud
 
 volumes:
   solr-data:

--- a/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
+++ b/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script installs the Solr configuration file from
+# MusicBrainz simple Solr search server schema (mbsssss).
+
 # Execute in a sub-shell to preserve the environment
 # (See the script run-initdb from Solr 9.7 repository)
 (

--- a/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
+++ b/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
@@ -5,6 +5,10 @@
 (
     set -e -o pipefail -u
 
+    if [[ "${VERBOSE:-}" == "yes" ]]; then
+        set -x
+    fi
+
     mbsssss_dir='/usr/lib/mbsssss'
     solr_conf_file='solr.xml'
 

--- a/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
+++ b/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Execute in a sub-shell to preserve the environment
+# (See the script run-initdb from Solr 9.7 repository)
+(
+    set -e -o pipefail -u
+
+    mbsssss_dir='/usr/lib/mbsssss'
+    solr_conf_file='solr.xml'
+
+    # Check if the Solr configuration file exists
+    if [[ ! -f "$SOLR_HOME/$solr_conf_file" ]]
+    then
+        echo 'Installing Solr configuration file...'
+        install --mode=0644 "$mbsssss_dir/$solr_conf_file" "$SOLR_HOME/"
+        echo 'Done installing Solr configuration file.'
+    fi
+)

--- a/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
+++ b/docker/entrypoint-initdb.d/10-install-musicbrainz-conf.sh
@@ -17,6 +17,7 @@
     then
         echo 'Installing Solr configuration file...'
         install --mode=0644 "$mbsssss_dir/$solr_conf_file" "$SOLR_HOME/"
+        touch $SOLR_HOME/musicbrainz-solrcloud-first-run
         echo 'Done installing Solr configuration file.'
     fi
 )

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -38,7 +38,15 @@ cd "$MAIN_DIR" >/dev/null
 for SUBDIR in $SUBDIRS; do
     FULL_PATH="$MAIN_DIR/$SUBDIR/conf"
     FULL_PATH=$(realpath "$FULL_PATH")
+    SOLR7SUBDIR_PATH="/var/solr/$SUBDIR"
     ZIP_FILE="$MAIN_DIR/$SUBDIR.zip"
+
+    # Check if Solr 7 data exists
+    if [[ -d "$SOLR7SUBDIR_PATH" ]]; then
+        echo "Removing Solr 7 data for $SUBDIR..."
+        rm -fr "$SOLR7SUBDIR_PATH"
+        echo "Removal successful."
+    fi
 
     # Check if the zip file exists
     if [ ! -f "$ZIP_FILE" ]; then

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -61,28 +61,33 @@ for SUBDIR in $SUBDIRS; do
             echo >&2 "Error zipping $FULL_PATH."
             exit 73 # EX_CANTCREAT
         fi
+        echo "Zip successful."
 
         # Return to the original directory
         cd - >/dev/null
     fi
 
     # Make the curl PUT request
-    echo "Uploading $ZIP_FILE to $UPLOAD_URL..."
-    if curl -X PUT --header "Content-Type:application/octet-stream" --data-binary @"$ZIP_FILE" "$UPLOAD_URL/$SUBDIR"; then
-        echo ""
+    echo "Uploading $ZIP_FILE to $UPLOAD_URL/$SUBDIR..."
+    if curl -sS -X PUT --header "Content-Type: application/octet-stream" --data-binary @"$ZIP_FILE" "$UPLOAD_URL/$SUBDIR"; then
+        echo
         echo "Upload successful."
 
         echo "Creating collection $SUBDIR..."
-        curl -X POST "$SOLR_BASE_URL/api/collections" \
+        curl -sS -X POST "$SOLR_BASE_URL/api/collections" \
             -H 'Content-Type: application/json' \
             --data-binary "{
                 \"name\": \"${SUBDIR}\",
                 \"config\": \"${SUBDIR}\",
                 \"numShards\": 1
             }"
+        echo
+        echo "Collection creation successful."
     else
-        echo ""
-        echo "Upload failed for $ZIP_FILE. Keeping the file for debugging."
+        echo
+        echo >&2 "Upload failed for $ZIP_FILE. Keeping the file for debugging."
+        exit 70 # EX_SOFTWARE
     fi
+    echo
 
 done

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -3,7 +3,7 @@
 set -e -o pipefail -u
 
 # Arguments
-MAIN_DIR="mbsssss"
+MAIN_DIR="/usr/lib/mbsssss"
 UPLOAD_URL="http://localhost:8983/api/cluster/configs"
 EXCLUDE_DIRS="lib common _template"
 

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -79,7 +79,8 @@ for SUBDIR in $SUBDIRS; do
             --data-binary "{
                 \"name\": \"${SUBDIR}\",
                 \"config\": \"${SUBDIR}\",
-                \"numShards\": 1
+                \"numShards\": 1,
+                \"waitForFinalState\": true
             }"
         echo
         echo "Collection creation successful."

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# This script uploads configsets to ZooKeeper through Solr API
+# and then creates Solr collections for MusicBrainz assuming:
+# - the file $SOLR_HOME/solr.xml is in place
+# - Solr is running in SolrCloud mode locally
+# - no configset has been uploaded yet
+# - no collection has been created either
+# It ignores arguments.
+
 set -euo pipefail
 echo "Executing $0" "$@"
 

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -8,7 +8,7 @@ UPLOAD_URL="http://localhost:8983/api/cluster/configs"
 EXCLUDE_DIRS="lib common _template"
 
 # Populate the list of subdirectories
-SUBDIRS=$(find $MAIN_DIR -maxdepth 1 -mindepth 1 -type d -print0 | xargs -0 -n 1 basename)
+SUBDIRS=$(find $MAIN_DIR -maxdepth 1 -mindepth 1 -type d -print0 | xargs -0 -n 1 basename | sort)
 
 # Exclude specified directories
 if [ -n "$EXCLUDE_DIRS" ]; then
@@ -17,38 +17,46 @@ if [ -n "$EXCLUDE_DIRS" ]; then
     done
 fi
 
+# Go to the main directory for mbsssss
+cd "$MAIN_DIR" >/dev/null
+
 # Iterate over the filtered subdirectories
 for SUBDIR in $SUBDIRS; do
     FULL_PATH="$MAIN_DIR/$SUBDIR/conf"
     FULL_PATH=$(realpath "$FULL_PATH")
+    ZIP_FILE="$MAIN_DIR/$SUBDIR.zip"
 
-    # Check if the subdirectory exists
-    if [ ! -d "$FULL_PATH" ]; then
-        echo >&2 "Directory $FULL_PATH does not exist."
-        exit 66 # EX_NOINPUT
-    fi
+    # Check if the zip file exists
+    if [ ! -f "$ZIP_FILE" ]; then
+        # Check if the subdirectory exists
+        if [ ! -d "$FULL_PATH" ]; then
+            echo >&2 "Directory $FULL_PATH does not exist."
+            exit 66 # EX_NOINPUT
+        fi
 
-    # Change to the directory being zipped
-    cd "$FULL_PATH" || {
-        echo >&2 "Failed to change to directory $FULL_PATH."
-        exit 74 # EX_IOERR
-    }
+        # Change to the directory being zipped
+        cd "$FULL_PATH" || {
+            echo >&2 "Failed to change to directory $FULL_PATH."
+            exit 74 # EX_IOERR
+        }
 
-    # Create a zip file of the subdirectory
-    ZIP_FILE="$SUBDIR.zip"
-    echo "Zipping $FULL_PATH into $ZIP_FILE..."
-    if ! zip -r "$ZIP_FILE" -- * >/dev/null; then
-        echo >&2 "Error zipping $FULL_PATH."
+        # Create a zip file of the subdirectory
+        ZIP_FILE="$MAIN_DIR/$SUBDIR.zip"
+        echo "Zipping $FULL_PATH into $ZIP_FILE..."
+        if ! zip -r "$ZIP_FILE" -- * >/dev/null; then
+            echo >&2 "Error zipping $FULL_PATH."
+            exit 73 # EX_CANTCREAT
+        fi
+
+        # Return to the original directory
         cd - >/dev/null
-        exit 73 # EX_CANTCREAT
     fi
 
     # Make the curl PUT request
     echo "Uploading $ZIP_FILE to $UPLOAD_URL..."
     if curl -X PUT --header "Content-Type:application/octet-stream" --data-binary @"$ZIP_FILE" "$UPLOAD_URL/$SUBDIR"; then
         echo ""
-        echo "Upload successful. Deleting $ZIP_FILE..."
-        rm "$ZIP_FILE"
+        echo "Upload successful."
 
         echo "Creating collection $SUBDIR..."
         curl -X POST http://localhost:8983/api/collections \
@@ -58,13 +66,9 @@ for SUBDIR in $SUBDIRS; do
                 \"config\": \"${SUBDIR}\",
                 \"numShards\": 1
             }"
-        echo ""
     else
         echo ""
         echo "Upload failed for $ZIP_FILE. Keeping the file for debugging."
     fi
-
-    # Return to the original directory
-    cd - >/dev/null
 
 done

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -9,7 +9,8 @@ fi
 
 # Arguments
 MAIN_DIR="/usr/lib/mbsssss"
-UPLOAD_URL="http://localhost:8983/api/cluster/configs"
+SOLR_BASE_URL="http://${SOLR_LOCAL_HOST:-localhost}:${SOLR_PORT:-8983}"
+UPLOAD_URL="$SOLR_BASE_URL/api/cluster/configs"
 EXCLUDE_DIRS="lib common _template"
 
 # Populate the list of subdirectories
@@ -64,7 +65,7 @@ for SUBDIR in $SUBDIRS; do
         echo "Upload successful."
 
         echo "Creating collection $SUBDIR..."
-        curl -X POST http://localhost:8983/api/collections \
+        curl -X POST "$SOLR_BASE_URL/api/collections" \
             -H 'Content-Type: application/json' \
             --data-binary "{
                 \"name\": \"${SUBDIR}\",

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-set -e -o pipefail -u
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
 
 # Arguments
 MAIN_DIR="/usr/lib/mbsssss"

--- a/docker/scripts/start-local-solrcloud
+++ b/docker/scripts/start-local-solrcloud
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# configure Solr to run on the local interface, and start it running in the background
+
+set -euo pipefail
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+echo "Running solr in the background. Logs are in /var/solr/logs"
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+if ! wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then
+    echo "Could not start Solr."
+    if [ -f "/var/solr/logs/solr.log" ]; then
+        echo "Here is the log:"
+        cat "/var/solr/logs/solr.log"
+    fi
+    exit 1
+fi

--- a/docker/scripts/start-local-solrcloud
+++ b/docker/scripts/start-local-solrcloud
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2006-2024 Apache Software Foundation
+# Copyright (c) 2025 MetaBrainz Foundation
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# configure Solr to run on the local interface, and start it running in the background
+# configure Solr to run on the local interface, and start it running in the background in SolrCloud mode
 
 set -euo pipefail
 
@@ -23,7 +27,7 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 echo "Running solr in the background. Logs are in /var/solr/logs"
-SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start
+SOLR_OPTS="-Djetty.host=${SOLR_LOCAL_HOST:-localhost}" solr start --cloud
 max_try=${MAX_TRY:-12}
 wait_seconds=${WAIT_SECONDS:-5}
 if ! wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"; then

--- a/docker/scripts/start-musicbrainz-solrcloud
+++ b/docker/scripts/start-musicbrainz-solrcloud
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script starts Solr on localhost, creates a core with "solr create",
+# stops Solr, and then starts Solr as normal.
+# Any arguments are passed to the "solr create".
+# To simply create a core:
+#      docker run -P -d solr solr-create -c mycore
+# To create a core from mounted config:
+#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+
+set -euo pipefail
+echo "Executing $0" "$@"
+
+if [[ "${VERBOSE:-}" == "yes" ]]; then
+    set -x
+fi
+
+# Could set env-variables for solr-fg
+source run-initdb
+
+# solr uses "-c corename". Parse the arguments to determine the core name.
+CORE_NAME="$(
+  while (( $# > 0 )); do
+    if [[ "$1" == '-c' ]]; then
+      shift
+      echo "$1"
+    fi
+    shift
+  done
+)"
+if [[ -z "${CORE_NAME:-}" ]]; then
+  echo "Could not determine core name"
+  exit 1
+fi
+
+coresdir=/var/solr/data
+CORE_DIR="$coresdir/$CORE_NAME"
+
+if [[ -d $CORE_DIR ]]; then
+    echo "Directory $CORE_DIR exists; skipping core creation"
+else
+    start-local-solr
+
+    echo "Creating core with:" "${@:1}"
+    /opt/solr/bin/solr create "${@:1}"
+
+    # See https://github.com/docker-solr/docker-solr/issues/27
+    echo "Checking core"
+    if ! wget -O - "http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=STATUS" | grep instanceDir >/dev/null; then
+      echo "Could not find any cores"
+      exit 1
+    fi
+
+    echo "Created core with:" "${@:1}"
+    stop-local-solr
+
+    # check the core_dir exists; otherwise the detecting above will fail after stop/start
+    if [ ! -d "$CORE_DIR" ]; then
+        echo "Missing $CORE_DIR"
+        exit 1
+    fi
+fi
+
+exec solr-fg

--- a/docker/scripts/start-musicbrainz-solrcloud
+++ b/docker/scripts/start-musicbrainz-solrcloud
@@ -18,10 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script starts Solr in SolrCloud mode on localhost,
+# At first run only, this script starts Solr in SolrCloud mode on localhost,
 # uploads the MusicBrainz configsets through API,
 # creates the corresponding collections through API too,
-# stops Solr, and then starts Solr in SolrCloud mode as normal.
+# and stops Solr.
+# Then, at any run, it starts Solr in SolrCloud mode as normal.
 # Any arguments are passed to the final "solr-fg --cloud" command.
 
 set -euo pipefail
@@ -35,10 +36,14 @@ fi
 # Install Solr configuration file
 source run-initdb
 
-start-local-solrcloud
+if [[ -f $SOLR_HOME/musicbrainz-solrcloud-first-run ]]; then
+    start-local-solrcloud
 
-create-musicbrainz-collections
+    create-musicbrainz-collections
 
-stop-local-solr
+    stop-local-solr
+
+    rm "$SOLR_HOME/musicbrainz-solrcloud-first-run"
+fi
 
 exec solr-fg --cloud "$@"

--- a/docker/scripts/start-musicbrainz-solrcloud
+++ b/docker/scripts/start-musicbrainz-solrcloud
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2006-2024 Apache Software Foundation
+# Copyright (c) 2025 MetaBrainz Foundation
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -14,13 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script starts Solr on localhost, creates a core with "solr create",
-# stops Solr, and then starts Solr as normal.
-# Any arguments are passed to the "solr create".
-# To simply create a core:
-#      docker run -P -d solr solr-create -c mycore
-# To create a core from mounted config:
-#      docker run -P -d -v $PWD/myconfig:/myconfig solr solr-create -c mycore -d /myconfig
+# This script starts Solr in SolrCloud mode on localhost,
+# uploads the MusicBrainz configsets through API,
+# creates the corresponding collections through API too,
+# stops Solr, and then starts Solr in SolrCloud mode as normal.
+# Any arguments are passed to the final "solr-fg --cloud" command.
 
 set -euo pipefail
 echo "Executing $0" "$@"
@@ -30,49 +32,13 @@ if [[ "${VERBOSE:-}" == "yes" ]]; then
 fi
 
 # Could set env-variables for solr-fg
+# Install Solr configuration file
 source run-initdb
 
-# solr uses "-c corename". Parse the arguments to determine the core name.
-CORE_NAME="$(
-  while (( $# > 0 )); do
-    if [[ "$1" == '-c' ]]; then
-      shift
-      echo "$1"
-    fi
-    shift
-  done
-)"
-if [[ -z "${CORE_NAME:-}" ]]; then
-  echo "Could not determine core name"
-  exit 1
-fi
+start-local-solrcloud
 
-coresdir=/var/solr/data
-CORE_DIR="$coresdir/$CORE_NAME"
+create-musicbrainz-collections
 
-if [[ -d $CORE_DIR ]]; then
-    echo "Directory $CORE_DIR exists; skipping core creation"
-else
-    start-local-solr
+stop-local-solr
 
-    echo "Creating core with:" "${@:1}"
-    /opt/solr/bin/solr create "${@:1}"
-
-    # See https://github.com/docker-solr/docker-solr/issues/27
-    echo "Checking core"
-    if ! wget -O - "http://localhost:${SOLR_PORT:-8983}/solr/admin/cores?action=STATUS" | grep instanceDir >/dev/null; then
-      echo "Could not find any cores"
-      exit 1
-    fi
-
-    echo "Created core with:" "${@:1}"
-    stop-local-solr
-
-    # check the core_dir exists; otherwise the detecting above will fail after stop/start
-    if [ ! -d "$CORE_DIR" ]; then
-        echo "Missing $CORE_DIR"
-        exit 1
-    fi
-fi
-
-exec solr-fg
+exec solr-fg --cloud "$@"

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-core</artifactId>
-			<version>9.5.0</version>
+			<version>9.6.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-analysis-icu</artifactId>
-			<version>9.9.2</version>
+			<version>9.10.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-analysis-extras</artifactId>
-			<version>9.5.0</version>
+			<version>9.6.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -80,19 +80,19 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-test-framework</artifactId>
-			<version>9.9.2</version>
+			<version>9.10.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-test-framework</artifactId>
-			<version>9.5.0</version>
+			<version>9.6.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-core</artifactId>
-			<version>9.9.2</version>
+			<version>9.10.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -122,13 +122,13 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.24</version>
+			<version>2.0.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.24</version>
+			<version>2.0.12</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-core</artifactId>
-			<version>9.6.1</version>
+			<version>9.7.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-analysis-icu</artifactId>
-			<version>9.10.0</version>
+			<version>9.11.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-analysis-extras</artifactId>
-			<version>9.6.1</version>
+			<version>9.7.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -80,19 +80,19 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-test-framework</artifactId>
-			<version>9.10.0</version>
+			<version>9.11.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-test-framework</artifactId>
-			<version>9.6.1</version>
+			<version>9.7.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-core</artifactId>
-			<version>9.10.0</version>
+			<version>9.11.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -122,13 +122,13 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.12</version>
+			<version>2.0.13</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
-			<version>2.0.12</version>
+			<version>2.0.13</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j</artifactId>
-			<version>74.2</version>
+			<version>75.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
@@ -59,12 +59,12 @@
 		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
-			<version>4.0.1</version>
+			<version>4.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
-			<version>4.0.4</version>
+			<version>4.0.5</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>eclipselink</artifactId>
-			<version>4.0.2</version>
+			<version>4.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
@@ -98,19 +98,19 @@
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
-			<version>1.2</version>
+			<version>1.3.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.xmlunit</groupId>
 			<artifactId>xmlunit-core</artifactId>
-			<version>2.5.1</version>
+			<version>2.10.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.javacrumbs.json-unit</groupId>
 			<artifactId>json-unit</artifactId>
-			<version>1.28.2</version>
+			<version>1.31.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -156,7 +156,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.7.1</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
@@ -185,7 +185,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.12.1</version>
+				<version>3.13.0</version>
 				<configuration>
 					<release>17</release>
 				</configuration>

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Arguments
+MAIN_DIR="mbsssss"
+UPLOAD_URL="http://localhost:8983/api/cluster/configs"
+EXCLUDE_DIRS="lib common _template"
+
+# Populate the list of subdirectories
+SUBDIRS=$(ls -d $MAIN_DIR/*/ | xargs -n 1 basename)
+
+# Exclude specified directories
+if [ -n "$EXCLUDE_DIRS" ]; then
+    for EXCLUDE_DIR in $EXCLUDE_DIRS; do
+        SUBDIRS=$(echo "$SUBDIRS" | grep -v "^$EXCLUDE_DIR$")
+    done
+fi
+
+# Iterate over the filtered subdirectories
+for SUBDIR in $SUBDIRS; do
+    FULL_PATH="$MAIN_DIR/$SUBDIR/conf"
+    FULL_PATH=$(realpath "$FULL_PATH")
+
+    # Check if the subdirectory exists
+    if [ ! -d "$FULL_PATH" ]; then
+        echo "Directory $FULL_PATH does not exist. Skipping..."
+        continue
+    fi
+
+    # Change to the directory being zipped
+    cd "$FULL_PATH" || { echo "Failed to change to directory $FULL_PATH. Skipping..."; continue; }
+
+    # Create a zip file of the subdirectory
+    ZIP_FILE="$SUBDIR.zip"
+    echo "Zipping $FULL_PATH into $ZIP_FILE..."
+    zip -r "$ZIP_FILE" * >/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "Error zipping $FULL_PATH. Skipping..."
+        cd - >/dev/null
+        continue
+    fi
+
+    # Make the curl PUT request
+    echo "Uploading $ZIP_FILE to $UPLOAD_URL..."
+    curl -X PUT --header "Content-Type:application/octet-stream" --data-binary @"$ZIP_FILE" "$UPLOAD_URL/$SUBDIR"
+    echo ""
+
+    if [ $? -eq 0 ]; then
+        echo "Upload successful. Deleting $ZIP_FILE..."
+        rm "$ZIP_FILE"
+
+        echo "Creating collection $SUBDIR..."
+        curl -X POST http://localhost:8983/api/collections \
+            -H 'Content-Type: application/json' \
+            --data-binary "{
+                \"name\": \"${SUBDIR}\",
+                \"config\": \"${SUBDIR}\",
+                \"numShards\": 1
+            }"
+        echo ""
+    else
+        echo "Upload failed for $ZIP_FILE. Keeping the file for debugging."
+    fi
+
+    # Return to the original directory
+    cd - >/dev/null
+
+done


### PR DESCRIPTION
Upgrade Solr version from 9.6.1 to 9.7.0 released in September (noticeably upgrading Lucene version to 9.11.1).

For references, please see commit message.

It follows the pull request #58.

Besides, it has been checked that neither `mmd-schema` nor `mbsssss` need any update to work with this new version.