### PR TITLE
SEARCH-732: Downgrade JFlex to 1.6.1

### DIFF
--- a/mb-solr/pom.xml
+++ b/mb-solr/pom.xml
@@ -138,7 +138,7 @@
 			<plugin>
 				<groupId>de.jflex</groupId>
 				<artifactId>jflex-maven-plugin</artifactId>
-				<version>1.9.1</version>
+				<version>1.6.1</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
In JFlex 1.8.0, the type of `yychar` was changed from `int` to `long` [1]. This causes a compilation error when MusicbrainzTokenizerImpl.java is regenerated. We would otherwise need to copy the changes from [1] into our MusicbrainzTokenizerImpl.jflex file -- though regnerating it with 1.9.1 produces many other changes in the tokenizer which I don't know the implications of. At the very least we'd have to rebuild all indexes.

JFlex was updated to 1.9.1 in 692c9aba9f9f22842ed71fc14c6c47a876b962f9 (I assume only "for good measure").

[1] https://github.com/apache/lucene/commit/af831d28