### PR TITLE
Add helper scripts to handle Solr backup archives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ USER root
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        # Needed to parse API JSON output in scripts
+        jq \
         # Needed to prepare uploading configsets
         zip \
         # Needed to decompress search index dumps

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,9 @@ RUN cd /usr/lib/mbsssss && \
         cd /usr/lib/mbsssss/"$conf_dir" && \
         zip -r /usr/lib/mbsssss/"$core_name".zip * && \
         chown solr:solr /usr/lib/mbsssss/"$core_name".zip * || exit 1; \
-    done
+    done && \
+    mkdir -p -m0770 /var/cache/musicbrainz/solr-backups && \
+    chown -R "$SOLR_USER:0" /var/cache/musicbrainz/solr-backups
 
 COPY --chmod=0755 \
      ./docker/entrypoint-initdb.d/* \
@@ -91,6 +93,8 @@ LABEL org.label-schema.build-date="${BUILD_DATE}" \
       org.metabrainz.based-on-image="${SOLR_NAME}:${SOLR_TAG}" \
       org.metabrainz.builder-image="maven:${MAVEN_TAG}" \
       org.metabrainz.mb-solr.version="${MB_SOLR_VERSION}"
+
+VOLUME /var/cache/musicbrainz/solr-backups
 
 # Restoring value set in the parent image
 USER solr

--- a/HACKING.md
+++ b/HACKING.md
@@ -73,8 +73,8 @@ Solr Admin
 To debug how other components (MBS, SIR) interact with the search server,
 the Solr Admin web interface (browsable from <http://localhost:8983>) is your friend.
 
-See “[Using the Solr Administration User Interface](https://solr.apache.org/guide/7_7/using-the-solr-administration-user-interface.html)”
-in the Apache Solr Reference Guide 7.7 for more information.
+See “[Getting Started / Solr Admin UI](https://solr.apache.org/guide/solr/latest/getting-started/solr-admin-ui.html)"
+in the Apache Solr Reference Guide 9.7 for more information.
 
 ### Query screen
 
@@ -115,8 +115,8 @@ These formats are incompatible with the “fl” field and the
 `debugQuery` and `explainOther` options, so setting any of these
 will not change the output.
 
-See “[Query Screen](https://solr.apache.org/guide/7_7/query-screen.html#query-screen)”
-in Apache Solr Reference Guide 7.7 for more information.
+See “[Query Screen](https://solr.apache.org/guide/solr/9_7/query-guide/query-screen.html)"
+in Apache Solr Reference Guide 9.7 for more information.
 
 #### Parameter priority
 

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -77,8 +77,8 @@ for SUBDIR in $SUBDIRS; do
 
     # Make the curl PUT request
     echo "Uploading $ZIP_FILE to $UPLOAD_URL/$SUBDIR..."
-    if curl -sS -X PUT --header "Content-Type: application/octet-stream" --data-binary @"$ZIP_FILE" "$UPLOAD_URL/$SUBDIR"; then
-        echo
+    upload_output="$(curl -sS -X PUT --header "Content-Type: application/octet-stream" --data-binary @"$ZIP_FILE" "$UPLOAD_URL/$SUBDIR")"
+    if [[ "$(echo "$upload_output" | jq .responseHeader.status)" =~ 0 ]]; then
         echo "Upload successful."
 
         case "$SUBDIR" in
@@ -86,19 +86,27 @@ for SUBDIR in $SUBDIRS; do
           *) SHARDS_COUNT=1;;
         esac
         echo "Creating collection $SUBDIR..."
-        curl -sS -X POST "$SOLR_BASE_URL/api/collections" \
-            -H 'Content-Type: application/json' \
-            --data-binary "{
-                \"name\": \"${SUBDIR}\",
-                \"config\": \"${SUBDIR}\",
-                \"numShards\": $SHARDS_COUNT,
-                \"waitForFinalState\": true
-            }"
-        echo
-        echo "Collection creation successful."
+        creation_output="$(
+            curl -sS -X POST "$SOLR_BASE_URL/api/collections" \
+                -H 'Content-Type: application/json' \
+                --data-binary "{
+                    \"name\": \"${SUBDIR}\",
+                    \"config\": \"${SUBDIR}\",
+                    \"numShards\": $SHARDS_COUNT,
+                    \"waitForFinalState\": true
+                }"
+            )"
+        if [[ "$(echo "$creation_output" | jq .responseHeader.status)" =~ 0 ]]; then
+            echo "$creation_output" | jq .success
+            echo "Collection creation successful."
+        else
+            echo >&2 "Collection creation failed for $SUBDIR. Leaving as is for debugging."
+            echo "$creation_output" | jq >&2
+            exit 70 # EX_SOFTWARE
+        fi
     else
-        echo
         echo >&2 "Upload failed for $ZIP_FILE. Keeping the file for debugging."
+        echo "$upload_output" | jq >&2
         exit 70 # EX_SOFTWARE
     fi
     echo

--- a/docker/scripts/create-musicbrainz-collections
+++ b/docker/scripts/create-musicbrainz-collections
@@ -81,13 +81,17 @@ for SUBDIR in $SUBDIRS; do
         echo
         echo "Upload successful."
 
+        case "$SUBDIR" in
+          'recording') SHARDS_COUNT=4;;
+          *) SHARDS_COUNT=1;;
+        esac
         echo "Creating collection $SUBDIR..."
         curl -sS -X POST "$SOLR_BASE_URL/api/collections" \
             -H 'Content-Type: application/json' \
             --data-binary "{
                 \"name\": \"${SUBDIR}\",
                 \"config\": \"${SUBDIR}\",
-                \"numShards\": 1,
+                \"numShards\": $SHARDS_COUNT,
                 \"waitForFinalState\": true
             }"
         echo

--- a/docker/scripts/delete-indexed-documents
+++ b/docker/scripts/delete-indexed-documents
@@ -75,9 +75,12 @@ for collection in "${collections[@]}"
 do
 	collection_index=$((collection_index + 1))
 	echo -n "Posting deletion query for the collection ($collection_index/$COLLECTIONS_TOTAL_COUNT) '$collection'... "
-	post \
-		-c "$collection" \
-		-d '<delete><query>*:*</query></delete>' >/dev/null
+	solr post \
+		--name "$collection" \
+		--mode args \
+		--type application/xml \
+		'<delete><query>*:*</query></delete>' \
+		2> >(grep -v deprecated >&2)
 	echo Done
 done
 

--- a/docker/scripts/delete-indexed-documents
+++ b/docker/scripts/delete-indexed-documents
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME --all
+   or: $SCRIPT_NAME COLLECTION... (for example: $SCRIPT_NAME artist release)
+   or: $SCRIPT_NAME --help
+
+For all or each of the given MusicBrainz Solr collections,
+delete the indexed documents.
+
+Pre-requisites:
+  Solr must be running (in SolrCloud mode).
+EOH
+)
+
+# Parse arguments
+
+if [ $# -eq 0 ]
+then
+	echo >&2 "$SCRIPT_NAME: missing argument"
+	echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+	exit 64 # EX_USAGE
+elif [[ "$*" =~ ^-*h(elp)?$ ]]
+then
+	echo "$HELP"
+	exit 0 # EX_OK
+elif [[ $# -eq 1 && $1 =~ ^-*all$ ]]
+then
+	collections=()
+else
+	collections=("$@")
+fi
+
+# Check pre-requisites
+
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+local_tries=1
+while [[ -f $SOLR_HOME/musicbrainz-solrcloud-first-run && $local_tries -lt $max_try ]]
+do
+	local_tries=$((local_tries + 1))
+	sleep "$wait_seconds"
+done
+if [[ -f $SOLR_HOME/musicbrainz-solrcloud-first-run ]] # $local_tries -eq $max_try
+then
+	echo >&2 "$SCRIPT_NAME: Solr first run is not complete (after waiting for $((max_try * wait_seconds)) seconds)"
+	echo >&2 "Try '$SCRIPT_NAME help' for pre-requisites."
+	exit 69 # EX_UNAVAILABLE
+fi
+if ! wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"
+then
+	echo >&2 "$SCRIPT_NAME: Solr is not running (after waiting for $((max_try * wait_seconds)) seconds)"
+	echo >&2 "Try '$SCRIPT_NAME help' for pre-requisites."
+	exit 69 # EX_UNAVAILABLE
+fi
+
+# List all the collections if needed
+
+if [[ ${#collections[@]} -eq 0 ]]
+then
+	readarray -t collections < <(find '/usr/lib/mbsssss' \
+		-maxdepth 1 -mindepth 1 -type d \
+		-not -name 'lib' -not -name 'common' -not -name '_template' \
+		-print0 | xargs -0 -n 1 basename | sort)
+fi
+
+# For each collection, delete all the indexed documents
+
+COLLECTIONS_TOTAL_COUNT=${#collections[@]}
+collection_index=0
+for collection in "${collections[@]}"
+do
+	collection_index=$((collection_index + 1))
+	echo -n "Posting deletion query for the collection ($collection_index/$COLLECTIONS_TOTAL_COUNT) '$collection'... "
+	post \
+		-c "$collection" \
+		-d '<delete><query>*:*</query></delete>' >/dev/null
+	echo Done
+done
+
+echo "Successfully posted all the deletion queries."
+
+# vi: set noexpandtab softtabstop=0:

--- a/docker/scripts/fetch-backup-archives
+++ b/docker/scripts/fetch-backup-archives
@@ -3,7 +3,7 @@
 set -e -o pipefail -u
 
 DB_DUMP_DIR=/media/dbdump
-SEARCH_DUMP_DIR=/media/searchdump
+SEARCH_DUMP_DIR=/var/cache/musicbrainz/solr-backups
 BASE_DOWNLOAD_URL="${MUSICBRAINZ_BASE_DOWNLOAD_URL:-https://data.metabrainz.org/pub/musicbrainz}"
 WGET_CMD=(wget)
 

--- a/docker/scripts/fetch-backup-archives
+++ b/docker/scripts/fetch-backup-archives
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+DB_DUMP_DIR=/media/dbdump
+SEARCH_DUMP_DIR=/media/searchdump
+BASE_DOWNLOAD_URL="${MUSICBRAINZ_BASE_DOWNLOAD_URL:-https://data.metabrainz.org/pub/musicbrainz}"
+WGET_CMD=(wget)
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<options>]
+
+Fetch backup archives of the MusicBrainz SolrCloud collections.
+
+Options:
+  --base-download-url <url>     Specify URL of a MetaBrainz/MusicBrainz download server.
+                                (Default: '$BASE_DOWNLOAD_URL')
+  --wget-options <wget options> Specify additional options to be passed to wget,
+                                these should be separated with whitespace,
+                                the list should be a single argument
+                                (escape whitespaces if needed).
+  -h, --help                    Print this help message and exit.
+
+Environment:
+  MUSICBRAINZ_BASE_DOWNLOAD_URL Default URL for MetaBrainz/MusicBrainz download server.
+EOH
+)
+
+# Parse arguments
+
+while [[ $# -gt 0 ]]
+do
+	case "$1" in
+		--base-download-url )
+			shift
+			BASE_DOWNLOAD_URL="${1%/data/fullexport/}"
+			if ! [[ $BASE_DOWNLOAD_URL =~ ^(ftp|https?):// ]]
+			then
+				echo >&2 "$SCRIPT_NAME: --base-download-url must begin with ftp://, http:// or https://"
+				exit 64 # EX_USAGE
+			fi
+			;;
+		--wget-options )
+			shift
+			IFS=' ' read -r -a WGET_OPTIONS <<< "$1"
+			WGET_CMD+=("${WGET_OPTIONS[@]}")
+			unset WGET_OPTIONS
+			;;
+		-h | --help )
+			echo "$HELP"
+			exit 0 # EX_OK
+			;;
+		-* )
+			echo >&2 "$SCRIPT_NAME: unrecognized option '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+		* )
+			echo >&2 "$SCRIPT_NAME: unrecognized argument '$1'"
+			echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+			exit 64 # EX_USAGE
+			;;
+	esac
+	shift
+done
+
+# Show information about signing up for data use
+
+if [[ ! -a "$DB_DUMP_DIR/.for-commercial-use" &&
+	! -a  "$DB_DUMP_DIR/.for-non-commercial-use" &&
+	! -a "$SEARCH_DUMP_DIR/.for-commercial-use" &&
+	! -a  "$SEARCH_DUMP_DIR/.for-non-commercial-use" ]]
+then
+	prompt=$(cat <<-EOQ
+		The data you are about to download is provided by the MetaBrainz Foundation.
+		Are you planning to use this data for commercial or business purposes?
+		(y/n)
+	EOQ
+	)
+	read -e -p "$prompt " -r
+	while [[ ! ${REPLY:0:1} =~ [YNyn] ]]
+	do
+		read -e -p "Invalid reply. Yes or no? " -r
+	done
+	echo
+	if [[ ${REPLY:0:1} =~ [Yy] ]]
+	then
+		prompt=$(cat <<-EOQ
+			The MetaBrainz Foundation is supported by commercial users of our data and
+			through end-user donations. If you are using our data in a commercial context,
+			we require you to support MetaBrainz financially in order for us ensure the
+			availability of these datasets in the future.
+			
+			Please sign up at https://metabrainz.org/supporters/account-type
+			
+			[Press any key when OK]
+		EOQ
+		)
+		read -e -N 1 -p "$prompt" -r -s
+		echo OK
+		touch "$SEARCH_DUMP_DIR/.for-commercial-use"
+	else
+		prompt=$(cat <<-EOQ
+			Could you please sign up at https://metabrainz.org/supporters/account-type
+			(for free!) so that we may better understand how our data is being used?
+			
+			We also encourage our non-commercial users who can afford it to make a donation
+			to the MetaBrainz Foundation so that we may continue our mission:
+			https://metabrainz.org/donate
+			
+			[Press any key when OK]
+		EOQ
+		)
+		read -e -N 1 -p "$prompt" -r -s
+		echo OK
+		touch "$SEARCH_DUMP_DIR/.for-non-commercial-use"
+	fi
+fi
+
+# Check timestamp for previously downloaded archives
+
+echo "$(date): 1/3: Checking timestamps of available archives..."
+
+PREVIOUS_DUMP_TIMESTAMP=''
+if [[ -a "$SEARCH_DUMP_DIR/LATEST" ]]
+then
+	PREVIOUS_DUMP_TIMESTAMP=$(<"$SEARCH_DUMP_DIR/LATEST")
+	rm -f "$SEARCH_DUMP_DIR/LATEST"
+fi
+
+# Check timestamp for remotely available archives
+
+"${WGET_CMD[@]}" -nd -nH -P "$SEARCH_DUMP_DIR" \
+	"${BASE_DOWNLOAD_URL}/data/solr-backups/LATEST"
+DUMP_TIMESTAMP=$(<"$SEARCH_DUMP_DIR/LATEST")
+
+# Remove previously downloaded files if new archives are available
+
+if [[ $PREVIOUS_DUMP_TIMESTAMP != "$DUMP_TIMESTAMP" ]]
+then
+	find "$SEARCH_DUMP_DIR" \
+		! -path "$SEARCH_DUMP_DIR" \
+		! -path "$SEARCH_DUMP_DIR/.for-commercial-use" \
+		! -path "$SEARCH_DUMP_DIR/.for-non-commercial-use" \
+		! -path "$SEARCH_DUMP_DIR/LATEST" \
+		-delete
+fi
+
+# Actually fetch latest MusicBrainz Solr backup archives
+
+echo "$(date): 2/3: Fetching MusicBrainz Solr backup archives..."
+"${WGET_CMD[@]}" -nd -nH -c -r -P "$SEARCH_DUMP_DIR" \
+	--accept 'MD5SUMS,*.tar.zst' --no-parent --relative \
+	"${BASE_DOWNLOAD_URL}/data/solr-backups/$DUMP_TIMESTAMP/"
+
+# Check archives integrity
+
+echo "$(date): 3/3: Checking MD5 sums..."
+cd "$SEARCH_DUMP_DIR" && md5sum -c MD5SUMS && cd - >/dev/null
+
+echo "$(date): Done fetching MusicBrainz Solr backup archives."
+# vi: set noexpandtab softtabstop=0:

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u
 
-DUMP_DIR="${MUSICBRAINZ_SEARCH_DUMP_DIR:-/media/searchdump}"
+DUMP_DIR="${MUSICBRAINZ_SEARCH_DUMP_DIR:-/var/cache/musicbrainz/solr-backups}"
 SOLR_BACKUPS_DIR="${SOLR_BACKUPS_DIR:-/var/solr/data/backups}"
 SOLR_BASE_URL="http://${SOLR_LOCAL_HOST:-localhost}:${SOLR_PORT:-8983}"
 
@@ -17,7 +17,7 @@ Options:
 
 Environment:
   MUSICBRAINZ_SEARCH_DUMP_DIR   path to directory with Solr backup archives
-                                (default: /media/searchdump)
+                                (default: /var/cache/musicbrainz/solr-backups)
   SOLR_BACKUPS_DIR              path to directory with Solr backup files
                                 (default: /var/solr/data/backups)
   SOLR_LOCAL_HOST               upstream Solr server listening host

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+DUMP_DIR="${MUSICBRAINZ_SEARCH_DUMP_DIR:-/media/searchdump}"
+SOLR_BACKUPS_DIR="${SOLR_BACKUPS_DIR:-/var/solr/data/backups}"
+SOLR_BASE_URL="http://${SOLR_LOCAL_HOST:-localhost}:${SOLR_PORT:-8983}"
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<options>]
+
+Load MusicBrainz Solr collections from fetched Solr backup archives.
+
+Options:
+  -h, --help    Print this help message
+
+Environment:
+  MUSICBRAINZ_SEARCH_DUMP_DIR   path to directory with Solr backup archives
+                                (default: /media/searchdump)
+  SOLR_BACKUPS_DIR              path to directory with Solr backup files
+                                (default: /var/solr/data/backups)
+  SOLR_LOCAL_HOST               upstream Solr server listening host
+                                (default: localhost)
+  SOLR_PORT                     upstream Solr server listening port
+                                (default: 8983)
+
+Pre-requisites:
+  Solr must be running (in SolrCloud mode).
+
+Notes:
+  It doesn't matter whether or not Solr has collections beforehand.
+
+  This command doesn't fetch the backup archives beforehand.
+  This command doesn't remove the backup archives afterwards.
+EOH
+)
+
+# Parse arguments
+
+if [[ $# -gt 0 && $1 =~ ^-*h(elp)?$ ]]
+then
+	echo "$HELP"
+	exit 0 # EX_OK
+elif [[ $# -gt 0 ]]
+then
+	echo >&2 "$SCRIPT_NAME: unrecognized arguments"
+	echo >&2 "Try '$SCRIPT_NAME help' for usage."
+	exit 64 # EX_USAGE
+fi
+
+# Check pre-requisites
+
+max_try=${MAX_TRY:-12}
+wait_seconds=${WAIT_SECONDS:-5}
+local_tries=1
+while [[ -f $SOLR_HOME/musicbrainz-solrcloud-first-run && $local_tries -lt $max_try ]]
+do
+	local_tries=$((local_tries + 1))
+	sleep "$wait_seconds"
+done
+if [[ -f $SOLR_HOME/musicbrainz-solrcloud-first-run && $local_tries -eq $max_try ]]
+then
+	echo >&2 "$SCRIPT_NAME: Solr first run is not complete (after waiting for $((max_try * wait_seconds)) seconds)"
+	echo >&2 "Try '$SCRIPT_NAME help' for pre-requisites."
+	exit 69 # EX_UNAVAILABLE
+fi
+if ! wait-for-solr.sh --max-attempts "$max_try" --wait-seconds "$wait_seconds"
+then
+	echo >&2 "$SCRIPT_NAME: Solr is not running (after waiting for $((max_try * wait_seconds)) seconds)"
+	echo >&2 "Try '$SCRIPT_NAME help' for pre-requisites."
+	exit 69 # EX_UNAVAILABLE
+fi
+
+# Process MusicBrainz Solr collection backup archives/dumps
+
+cd "$DUMP_DIR"
+
+mkdir -p "$SOLR_BACKUPS_DIR"
+
+DUMP_TOTAL_COUNT=$(find . -maxdepth 1 -name '*.tar.zst' 2>/dev/null | wc -l)
+dump_proc_count=0
+
+for dump_file in *.tar.zst
+do
+	collection=${dump_file/.tar.zst}
+	dump_proc_count=$((dump_proc_count + 1))
+	echo "$SCRIPT_NAME: $(date): Load MusicBrainz Solr collection ($dump_proc_count/$DUMP_TOTAL_COUNT): '$collection'..."
+
+	if find "$SOLR_BACKUPS_DIR" -path "./$collection" -type d 2>/dev/null
+	then
+		echo "$SCRIPT_NAME: $(date): Delete the pre-existing backup '$collection'..."
+		rm -fr "${SOLR_BACKUPS_DIR:?}/$collection"
+	fi
+
+	echo "$SCRIPT_NAME: $(date): Extract the backup archive '$dump_file' ($(du -h "$dump_file" | cut -f1))..."
+	# Skip the files COPYING and README that would get Solr stuck otherwise
+	tar -x --zstd -f "$DUMP_DIR/$dump_file" -C "$SOLR_BACKUPS_DIR" "$collection/$collection"
+
+	echo "$SCRIPT_NAME: $(date): Restore the collection '$collection' from backup..."
+	restore_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=RESTORE&collection=$collection&name=$collection&location=$SOLR_BACKUPS_DIR")"
+	if [[ ! "$(echo "$restore_output" | jq .responseHeader.status)" =~ 0 ]]
+	then
+		echo >&2 "$SCRIPT_NAME: Fatal error while restoring the collection '$collection':"
+		echo >&2 "$(echo "$restore_output" | jq .error.code): $(echo "$restore_output" | jq -r .error.msg)"
+		exit 70 # EX_SOFTWARE
+	fi
+
+	echo "$SCRIPT_NAME: $(date): Delete the no-longer-needed backup '$collection'..."
+	find "$SOLR_BACKUPS_DIR/$collection" -type f -delete
+
+	echo "$SCRIPT_NAME: $(date): Done loading MusicBrainz Solr collection '$collection'."
+done
+
+echo "$SCRIPT_NAME: $(date): Done loading all the MusicBrainz Solr collections."
+
+# vi: set noexpandtab softtabstop=0:

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -10,13 +10,13 @@ SCRIPT_NAME=$(basename "$0")
 HELP=$(cat <<EOH
 Usage: $SCRIPT_NAME [<options>]
 
-Load MusicBrainz Solr collections from fetched Solr backup archives.
+Load MusicBrainz Solr collections from Solr backup (tar) archives.
 
 Options:
   -h, --help    Print this help message
 
 Environment:
-  MUSICBRAINZ_SEARCH_DUMP_DIR   path to directory with Solr backup archives
+  MUSICBRAINZ_SEARCH_DUMP_DIR   path to directory with Solr backup tar archives
                                 (default: /var/cache/musicbrainz/solr-backups)
   SOLR_BACKUPS_DIR              path to directory with Solr backup files
                                 (default: /var/solr/data/backups)
@@ -31,8 +31,12 @@ Pre-requisites:
 Notes:
   It doesn't matter whether or not Solr has collections beforehand.
 
-  This command doesn't fetch the backup archives beforehand.
-  This command doesn't remove the backup archives afterwards.
+  This command doesn't fetch the backup tar archives beforehand.
+  This command doesn't remove the backup tar archives afterwards.
+
+  In detail, it extracts the backup files from the tar archives, then
+  it queries Solr API to restore the collections from these backup files,
+  and last it deletes these backup files (not the backup tar archives).
 EOH
 )
 
@@ -97,7 +101,7 @@ do
 	# Skip the files COPYING and README that would get Solr stuck otherwise
 	tar -x --zstd -f "$DUMP_DIR/$dump_file" -C "$SOLR_BACKUPS_DIR" "$collection/$collection"
 
-	echo "$SCRIPT_NAME: $(date): Restore the collection '$collection' from backup..."
+	echo "$SCRIPT_NAME: $(date): Restore the collection '$collection' from extracted backup..."
 	restore_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=RESTORE&collection=$collection&name=$collection&location=$SOLR_BACKUPS_DIR")"
 	if [[ ! "$(echo "$restore_output" | jq .responseHeader.status)" =~ 0 ]]
 	then
@@ -106,7 +110,7 @@ do
 		exit 70 # EX_SOFTWARE
 	fi
 
-	echo "$SCRIPT_NAME: $(date): Delete the no-longer-needed backup '$collection'..."
+	echo "$SCRIPT_NAME: $(date): Delete the no-longer-needed extracted backup '$collection'..."
 	find "$SOLR_BACKUPS_DIR/$collection" -type f -delete
 
 	echo "$SCRIPT_NAME: $(date): Done loading MusicBrainz Solr collection '$collection'."

--- a/docker/scripts/remove-backup-archives
+++ b/docker/scripts/remove-backup-archives
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u
 
-DUMP_DIR="${MUSICBRAINZ_SEARCH_DUMP_DIR:-/media/searchdump}"
+DUMP_DIR="${MUSICBRAINZ_SEARCH_DUMP_DIR:-/var/cache/musicbrainz/solr-backups}"
 
 SCRIPT_NAME=$(basename "$0")
 HELP=$(cat <<EOH
@@ -15,7 +15,7 @@ Options:
 
 Environment:
   MUSICBRAINZ_SEARCH_DUMP_DIR   path to directory with Solr backup archives
-                                (default: /media/searchdump)
+                                (default: /var/cache/musicbrainz/solr-backups)
 
 Notes:
   It doesn't remove timestamp, checksum, and signature files, because

--- a/docker/scripts/remove-backup-archives
+++ b/docker/scripts/remove-backup-archives
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+DUMP_DIR="${MUSICBRAINZ_SEARCH_DUMP_DIR:-/media/searchdump}"
+
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [<options>]
+
+Remove MusicBrainz Solr collection backup archives.
+
+Options:
+  -h, --help    Print this help message
+
+Environment:
+  MUSICBRAINZ_SEARCH_DUMP_DIR   path to directory with Solr backup archives
+                                (default: /media/searchdump)
+
+Notes:
+  It doesn't remove timestamp, checksum, and signature files, because
+  their size is insignificant but they are useful to investigate issues.
+EOH
+)
+
+# Parse arguments
+
+if [[ $# -gt 0 && $1 =~ ^-*h(elp)?$ ]]
+then
+	echo "$HELP"
+	exit 0 # EX_OK
+elif [[ $# -gt 0 ]]
+then
+	echo >&2 "$SCRIPT_NAME: unrecognized arguments"
+	echo >&2 "Try '$SCRIPT_NAME help' for usage."
+	exit 64 # EX_USAGE
+fi
+
+# Just remove MusicBrainz Solr collection backup archives/dumps
+
+dump_size="$(du -h "$DUMP_DIR" | cut -f1))"
+rm -frv "${DUMP_DIR:?}/"*.tar.zst
+echo "$SCRIPT_NAME: $(date): Removed $dump_size of Solr backup archives."
+
+# vi: set noexpandtab softtabstop=0:


### PR DESCRIPTION
# Problem

It follows the pull request https://github.com/metabrainz/musicbrainz-server/pull/3525/.

With SEARCH-685 (Upgrade to Solr 9), a new format is required for backing up collections with SolrCloud for initializing with MusicBrainz mirrors.

More generally, MusicBrainz Solr helper scripts should rather belong to this repository rather than adding complexity to the MusicBrainz Docker setup.

# Solution

This patch allows to make SolrCloud 8.9+ collections (formerly named as search indexes) backups available for use with MusicBrainz live mirrors. It mainly adapts the container and scripts that were used to dump Solr 7 search indexes.

See the commit messages for details.

# Testing

* [x] Pass `shellcheck`
* [x] Run manually on `hip` in a `musicbrainz-docker` instance (with an extra Docker volume for backup archives)
  It takes about 25min and up to 200G as follows:
  * [x] start `search` service for the first time (<1min)
  * [x] `fetch-backup-archives` (<12min)
    Backup archives take 58G
  * [x] `load-backup-archives` (<12min)
    Solr collection files take 74G
    The largest (`recording`) backup files take 72G (before deletion)
  * [x] `remove-backup-archives` (<1min)
  * [x] `delete-indexed-documents --all` (<1min)

# Documenting

Each script is self-documented through HELP message.

# Further action

On merge, we have to:
* change the volume for MusicBrainz Solr backup archives in `musicbrainz-docker`,
* trim the corresponding scripts from `musicbrainz-docker`,
* update both repositories’ documentation.