### PR TITLE
Fix "RAMDirectory can only be used with the 'single' lock factory type." in tests

### DIFF
--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterTest.java
@@ -7,6 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -17,7 +18,8 @@ public abstract class AbstractMBWriterTest extends SolrTestCaseJ4 implements
 		MBWriterTestInterface {
 	@BeforeClass
 	public static void beforeClass() throws Exception {
-		initCore("solrconfig.xml", "schema.xml", "../mbsssss", getCorename());
+		System.setProperty("solr.directoryFactory", "solr.NRTCachingDirectoryFactory");
+		initCore("solrconfig.xml", "schema.xml", new File("../mbsssss").getAbsolutePath(), getCorename());
 	}
 
 	public static String corename;


### PR DESCRIPTION
This broke in 74eca42a935d1e950aeac8843e3a04c198c92737.

I believe `SolrTestCaseJ4` is overriding our default `solr.NRTCachingDirectoryFactory` value from
./mbsssss/common/directoryFactory.xml via [1]. (Apparently Solr 9.5.0 also did this, so something else must've changed too.)

Using `RAMDirectoryFactory` for running tests does make sense, although it's apparently been deprecated in favor of `ByteBuffersDirectoryFactory`.  However, changing the tests to use `ByteBuffersDirectoryFactory` gives the same "can only be used with the 'single' lock factory type" error.

I couldn't figure out how to override the lock type in the tests. Although it could be done in the solrconfig, those are also used in production.

Using `solr.NRTCachingDirectoryFactory` otherwise works fine, except it requires an absolute path to mbsssss.

[1] https://github.com/apache/solr/blob/releases/solr/9.7.0/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java#L813

@amCap1712 you might have a better idea of how to fix this properly