### PR TITLE
SEARCH-738 (writer): Support medium MBIDs

### DIFF
--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.json
@@ -86,6 +86,7 @@
                     "media": [
                         {
                             "position": 1,
+                            "id": "ac404674-891f-4e01-8d28-d77b43690d2a",
                             "format": "CD",
                             "track": [
                                 {
@@ -137,6 +138,7 @@
                     "media": [
                         {
                             "position": 5,
+                            "id": "01b9d64d-1d6d-4494-af8e-830ecf9f737d",
                             "format": "DVD",
                             "track": [
                                 {

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording-list.xml
@@ -45,7 +45,7 @@
                     </release-event-list>
                     <medium-list>
                         <track-count>106</track-count>
-                        <medium>
+                        <medium id="ac404674-891f-4e01-8d28-d77b43690d2a">
                             <position>1</position>
                             <format>CD</format>
                             <track-list count="15" offset="0">
@@ -84,7 +84,7 @@
                     </release-event-list>
                     <medium-list>
                         <track-count>106</track-count>
-                        <medium>
+                        <medium id="01b9d64d-1d6d-4494-af8e-830ecf9f737d">
                             <position>5</position>
                             <format>DVD</format>
                             <track-list count="53" offset="0">

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/recording.xml
@@ -42,7 +42,7 @@
             </release-event-list>
             <medium-list>
                 <track-count>106</track-count>
-                <medium>
+                <medium id="ac404674-891f-4e01-8d28-d77b43690d2a">
                     <position>1</position>
                     <format>CD</format>
                     <track-list count="15" offset="0">
@@ -81,7 +81,7 @@
             </release-event-list>
             <medium-list>
                 <track-count>106</track-count>
-                <medium>
+                <medium id="01b9d64d-1d6d-4494-af8e-830ecf9f737d">
                     <position>5</position>
                     <format>DVD</format>
                     <track-list count="53" offset="0">

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.json
@@ -74,6 +74,7 @@
             "track-count": 51,
             "media": [
                 {
+                    "id": "47ceaa3e-405c-4f9b-8999-5e4f7fd2134b",
                     "format": "Digital Media",
                     "disc-count": 0,
                     "track-count": 51

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release-list.xml
@@ -50,7 +50,7 @@
             </label-info-list>
             <medium-list count="1">
                 <track-count>51</track-count>
-                <medium>
+                <medium id="47ceaa3e-405c-4f9b-8999-5e4f7fd2134b">
                     <format>Digital Media</format>
                     <disc-list count="0"/>
                     <track-list count="51"/>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/release.xml
@@ -47,7 +47,7 @@
     </label-info-list>
     <medium-list count="1">
         <track-count>51</track-count>
-        <medium>
+        <medium id="47ceaa3e-405c-4f9b-8999-5e4f7fd2134b">
             <format>Digital Media</format>
             <disc-list count="0"/>
             <track-list count="51"/>


### PR DESCRIPTION
# Problem: SEARCH-738 (writer part)

Search server doesn’t include MBID in results for search indexes (recording, release) that have mediums.


# Solution

* Switch `mmd-schema` used to write the results to an (upcoming) version that includes medium MBID;
* Update XML and JSON tests accordingly


# Todolist before merging
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Test it locally with latest `mmd-schema` version; See https://github.com/metabrainz/sir/pull/160
* [x] Soon before release (since it updates `/doc` immediately), update the [MusicBrainz API Search](https://wiki.musicbrainz.org/MusicBrainz_API/Search) examples in XML and JSON and the Search Fields section.

# Action after merging
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Release and deploy
2. After rebuilding indexes with <https://github.com/metabrainz/sir/pull/157>,
   make the updated WikiDocs page visible on MusicBrainz website