### PR TITLE
Set the default command in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ LABEL org.label-schema.build-date="${BUILD_DATE}" \
       org.metabrainz.mb-solr.version="${MB_SOLR_VERSION}"
 
 VOLUME /var/cache/musicbrainz/solr-backups
+CMD start-musicbrainz-solrcloud
 
 # Restoring value set in the parent image
 USER solr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - "127.0.0.1:8983:8983"
     volumes:
       - solr-data:/var/solr
-    command: start-musicbrainz-solrcloud
 
 volumes:
   solr-data:


### PR DESCRIPTION
The command `start-musicbrainz-solrcloud` allows to start the container cleanly after initializing configsets and collections if needed. This patch sets it as the default command in the image directly instead of requiring to specify it with Docker run (or Docker Compose command).