### PR TITLE
SEARCH-751: Add the target-type property to relationships in event and work JSON

### DIFF
--- a/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/EventAdapter.java
+++ b/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/EventAdapter.java
@@ -42,10 +42,10 @@ public class EventAdapter extends NotUnmarshallableXmlAdapter<EventAdapter.Adapt
     }
 
     /**
-     * Call when convert model to json, replaces work in model with adaptedWork
+     * Call when convert model to json, replaces event in model with adaptedEvent
      * which does not contain a list of RelationList, instead all relations in each existing
      * RelationList are merged into a list of relations. We do this because it is not possible to merge
-     * a List of RelationLists into the work using oxml.xml mapping
+     * a List of RelationLists into the event using oxml.xml mapping
      */
     @Override
     public AdaptedEvent marshal(Event event) throws Exception {

--- a/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/RelationAdapter.java
+++ b/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/RelationAdapter.java
@@ -1,0 +1,79 @@
+/* Copyright (c) 2026 MetaBrainz Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the MusicBrainz project nor the names of the
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.musicbrainz.search.solrwriter.moxy;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import org.musicbrainz.mmd2.Relation;
+
+/**
+ * This adapter class only exists to extend `Relation` with a `target-type`
+ * attribute. Since the target type is only accessible on the parent
+ * `RelationList`, it's not actually assigned to here, but via
+ * `RelationListUtil.marshal`. All other relation properties are copied onto
+ * the adapted relation instance as-is.
+ */
+
+public class RelationAdapter extends NotUnmarshallableXmlAdapter<RelationAdapter.AdaptedRelation, Relation> {
+
+    public static class AdaptedRelation extends Relation {
+        @XmlElement(name = "target-type")
+        protected String targetType;
+    }
+
+    @Override
+    public AdaptedRelation marshal(Relation relation) throws Exception {
+        AdaptedRelation adaptedRelation = new AdaptedRelation();
+
+        adaptedRelation.setOrderingKey(relation.getOrderingKey());
+        adaptedRelation.setDirection(relation.getDirection());
+        adaptedRelation.setAttributeList(relation.getAttributeList());
+        adaptedRelation.setBegin(relation.getBegin());
+        adaptedRelation.setEnd(relation.getEnd());
+        adaptedRelation.setEnded(relation.getEnded());
+        adaptedRelation.setSourceCredit(relation.getSourceCredit());
+        adaptedRelation.setTargetCredit(relation.getTargetCredit());
+        adaptedRelation.setType(relation.getType());
+        adaptedRelation.setTypeId(relation.getTypeId());
+
+        adaptedRelation.setArea(relation.getArea());
+        adaptedRelation.setArtist(relation.getArtist());
+        adaptedRelation.setEvent(relation.getEvent());
+        adaptedRelation.setInstrument(relation.getInstrument());
+        adaptedRelation.setLabel(relation.getLabel());
+        adaptedRelation.setPlace(relation.getPlace());
+        adaptedRelation.setRecording(relation.getRecording());
+        adaptedRelation.setRelease(relation.getRelease());
+        adaptedRelation.setReleaseGroup(relation.getReleaseGroup());
+        adaptedRelation.setSeries(relation.getSeries());
+        adaptedRelation.setTarget(relation.getTarget());
+        adaptedRelation.setWork(relation.getWork());
+
+        return adaptedRelation;
+    }
+}

--- a/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/RelationListUtil.java
+++ b/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/RelationListUtil.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012 Paul Taylor
+/* Copyright (c) 2026 MetaBrainz Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,43 +28,24 @@
 
 package org.musicbrainz.search.solrwriter.moxy;
 
-import org.musicbrainz.mmd2.Event;
 import org.musicbrainz.mmd2.Relation;
 import org.musicbrainz.mmd2.RelationList;
-
 import java.util.ArrayList;
 import java.util.List;
 
-public class EventAdapter extends NotUnmarshallableXmlAdapter<EventAdapter.AdaptedEvent, Event> {
+public class RelationListUtil {
 
-    public static class AdaptedEvent extends Event {
-        public List<RelationAdapter.AdaptedRelation> relations;
-    }
-
-    /**
-     * Call when convert model to json, replaces event in model with adaptedEvent
-     * which does not contain a list of RelationList, instead all relations in each existing
-     * RelationList are merged into a list of relations. We do this because it is not possible to merge
-     * a List of RelationLists into the event using oxml.xml mapping
-     */
-    @Override
-    public AdaptedEvent marshal(Event event) throws Exception {
-        AdaptedEvent adaptedEvent = new AdaptedEvent();
-        adaptedEvent.relations = RelationListUtil.marshal(event.getRelationList());
-
-        //Also need to copy any other elements/attributes we may want to output
-        adaptedEvent.setAliasList(event.getAliasList());
-        adaptedEvent.setDisambiguation(event.getDisambiguation());
-        adaptedEvent.setId(event.getId());
-        adaptedEvent.setName(event.getName());
-        adaptedEvent.setTime(event.getTime());
-        adaptedEvent.setLifeSpan(event.getLifeSpan());
-        adaptedEvent.setRating(event.getRating());
-        adaptedEvent.setScore(event.getScore());
-        adaptedEvent.setTagList(event.getTagList());
-        adaptedEvent.setType(event.getType());
-        adaptedEvent.setUserRating(event.getUserRating());
-        adaptedEvent.setUserTagList(event.getUserTagList());
-        return adaptedEvent;
+    public static List<RelationAdapter.AdaptedRelation> marshal(List<RelationList> relationLists) throws Exception {
+        List<RelationAdapter.AdaptedRelation> relations = new ArrayList<>();
+        RelationAdapter adapter = new RelationAdapter();
+        for (RelationList relationList : relationLists) {
+            String targetType = relationList.getTargetType();
+            for (Relation relation : relationList.getRelation()) {
+                RelationAdapter.AdaptedRelation adaptedRelation = adapter.marshal(relation);
+                adaptedRelation.targetType = targetType;
+                relations.add(adaptedRelation);
+            }
+        }
+        return relations;
     }
 }

--- a/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/WorkAdapter.java
+++ b/mb-solr/src/main/java/org/musicbrainz/search/solrwriter/moxy/WorkAdapter.java
@@ -39,7 +39,7 @@ import java.util.List;
 public class WorkAdapter extends NotUnmarshallableXmlAdapter<WorkAdapter.AdaptedWork, Work> {
 
     public static class AdaptedWork extends Work {
-        public List<Relation> relations = new ArrayList<Relation>();
+        public List<RelationAdapter.AdaptedRelation> relations;
         public List<String> languages = new ArrayList<String>();
     }
 
@@ -53,11 +53,7 @@ public class WorkAdapter extends NotUnmarshallableXmlAdapter<WorkAdapter.Adapted
     public AdaptedWork marshal(Work work) throws Exception {
 
         AdaptedWork adaptedWork = new AdaptedWork();
-        for(RelationList relationList : work.getRelationList()) {
-            for(Relation relation : relationList.getRelation()) {
-                adaptedWork.relations.add(relation);
-            }
-        }
+        adaptedWork.relations = RelationListUtil.marshal(work.getRelationList());
 
         LanguageList languageList = work.getLanguageList();
         if (languageList != null)

--- a/mb-solr/src/main/resources/oxml.xml
+++ b/mb-solr/src/main/resources/oxml.xml
@@ -275,6 +275,7 @@
             </java-attributes>
         </java-type>
         <java-type name="Relation">
+            <xml-java-type-adapter value="org.musicbrainz.search.solrwriter.moxy.RelationAdapter"/>
             <java-attributes>
                 <xml-element java-attribute="attributeList" xml-path="."/>
                 <xml-element java-attribute="target">

--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterEventTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterEventTest.java
@@ -1,0 +1,13 @@
+package org.musicbrainz.search.solrwriter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public abstract class AbstractMBWriterEventTest extends AbstractMBWriterTest {
+	@Override
+	public ArrayList<String> getDoc() {
+		return new ArrayList<>(Arrays.asList(new String[]{
+				"event", "Wacken Open Air 2024",
+				"mbid", uuid}));
+	}
+}

--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterWorkTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/AbstractMBWriterWorkTest.java
@@ -1,0 +1,13 @@
+package org.musicbrainz.search.solrwriter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public abstract class AbstractMBWriterWorkTest extends AbstractMBWriterTest {
+	@Override
+	public ArrayList<String> getDoc() {
+		return new ArrayList<>(Arrays.asList(new String[]{
+				"work", "Poker Face",
+				"mbid", uuid}));
+	}
+}

--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/json/MBJSONWriterEventTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/json/MBJSONWriterEventTest.java
@@ -1,0 +1,10 @@
+package org.musicbrainz.search.solrwriter.json;
+
+import org.musicbrainz.search.solrwriter.AbstractMBWriterEventTest;
+import org.musicbrainz.search.solrwriter.MBJSONWriterTestInterface;
+
+public class MBJSONWriterEventTest extends AbstractMBWriterEventTest implements MBJSONWriterTestInterface {
+	static {
+		corename = "event";
+	}
+}

--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/json/MBJSONWriterWorkTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/json/MBJSONWriterWorkTest.java
@@ -1,0 +1,10 @@
+package org.musicbrainz.search.solrwriter.json;
+
+import org.musicbrainz.search.solrwriter.AbstractMBWriterWorkTest;
+import org.musicbrainz.search.solrwriter.MBJSONWriterTestInterface;
+
+public class MBJSONWriterWorkTest extends AbstractMBWriterWorkTest implements MBJSONWriterTestInterface {
+	static {
+		corename = "work";
+	}
+}

--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/xml/MBXMLWriterEventTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/xml/MBXMLWriterEventTest.java
@@ -1,0 +1,10 @@
+package org.musicbrainz.search.solrwriter.xml;
+
+import org.musicbrainz.search.solrwriter.AbstractMBWriterEventTest;
+import org.musicbrainz.search.solrwriter.MBXMLWriterTestInterface;
+
+public class MBXMLWriterEventTest extends AbstractMBWriterEventTest implements MBXMLWriterTestInterface {
+	static {
+		corename = "event";
+	}
+}

--- a/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/xml/MBXMLWriterWorkTest.java
+++ b/mb-solr/src/test/java/org/musicbrainz/search/solrwriter/xml/MBXMLWriterWorkTest.java
@@ -1,0 +1,10 @@
+package org.musicbrainz.search.solrwriter.xml;
+
+import org.musicbrainz.search.solrwriter.AbstractMBWriterWorkTest;
+import org.musicbrainz.search.solrwriter.MBXMLWriterTestInterface;
+
+public class MBXMLWriterWorkTest extends AbstractMBWriterWorkTest implements MBXMLWriterTestInterface {
+	static {
+		corename = "work";
+	}
+}

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event-list.json
@@ -1,0 +1,29 @@
+{
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
+    "count": 1,
+    "offset": 0,
+    "events": [
+        {
+            "id": "183ba1ec-a87b-4c0e-85dd-496b7cea4399",
+            "type": "Festival",
+            "score": 100,
+            "name": "Wacken Open Air 2024",
+            "life-span": {
+                "begin": "2024-07-31",
+                "end": "2024-08-03"
+            },
+            "relations": [
+                {
+                    "type": "held at",
+                    "type-id": "e2c6f697-07dc-38b1-be0b-83d740165532",
+                    "target": "3acd3d34-e8ea-4b9d-be0f-bd1e128aa8ba",
+                    "direction": "backward",
+                    "place": {
+                        "id": "3acd3d34-e8ea-4b9d-be0f-bd1e128aa8ba",
+                        "name": "Wacken Open Air Festival Grounds"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event-list.json
@@ -14,6 +14,7 @@
             },
             "relations": [
                 {
+                    "target-type": "place",
                     "type": "held at",
                     "type-id": "e2c6f697-07dc-38b1-be0b-83d740165532",
                     "target": "3acd3d34-e8ea-4b9d-be0f-bd1e128aa8ba",

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event-list.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0" xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+	<event-list count="1" offset="0">
+		<event id="183ba1ec-a87b-4c0e-85dd-496b7cea4399" type="Festival" type-id="b6ded574-b592-3f0e-b56e-5b5f06aa0678" ns2:score="100">
+			<name>Wacken Open Air 2024</name>
+			<life-span>
+				<begin>2024-07-31</begin>
+				<end>2024-08-03</end>
+			</life-span>
+			<relation-list target-type="place">
+				<relation type="held at" type-id="e2c6f697-07dc-38b1-be0b-83d740165532">
+					<target>3acd3d34-e8ea-4b9d-be0f-bd1e128aa8ba</target>
+					<direction>backward</direction>
+					<place id="3acd3d34-e8ea-4b9d-be0f-bd1e128aa8ba">
+						<name>Wacken Open Air Festival Grounds</name>
+					</place>
+				</relation>
+			</relation-list>
+		</event>
+	</event-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/event.xml
@@ -1,0 +1,15 @@
+<event xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="183ba1ec-a87b-4c0e-85dd-496b7cea4399" type="Festival" type-id="b6ded574-b592-3f0e-b56e-5b5f06aa0678">
+	<name>Wacken Open Air 2024</name>
+	<life-span>
+		<begin>2024-07-31</begin>
+		<end>2024-08-03</end>
+	</life-span>
+	<relation-list target-type="place">
+		<relation type="held at" type-id="e2c6f697-07dc-38b1-be0b-83d740165532">
+			<direction>backward</direction>
+			<place id="3acd3d34-e8ea-4b9d-be0f-bd1e128aa8ba">
+				<name>Wacken Open Air Festival Grounds</name>
+			</place>
+		</relation>
+	</relation-list>
+</event>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work-list.json
@@ -23,6 +23,7 @@
             ],
             "relations": [
                 {
+                    "target-type": "artist",
                     "type": "writer",
                     "type-id": "a255bca1-b157-4518-9108-7b147dc3fc68",
                     "target": "650e7db6-b795-4eb5-a702-5ea2fc46c848",
@@ -34,6 +35,7 @@
                     }
                 },
                 {
+                    "target-type": "artist",
                     "type": "writer",
                     "type-id": "a255bca1-b157-4518-9108-7b147dc3fc68",
                     "target": "8c84402d-f282-4afc-8d64-049bdaabb92d",
@@ -45,6 +47,7 @@
                     }
                 },
                 {
+                    "target-type": "recording",
                     "type": "performance",
                     "type-id": "a3005666-a872-32c3-ad06-98af558e99b0",
                     "target": "f8bbe5a7-bc01-4780-aee0-aef98666b874",

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work-list.json
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work-list.json
@@ -1,0 +1,62 @@
+{
+    "created": "${json-unit.matches:validXMLGregorianCalendar}",
+    "count": 1,
+    "offset": 0,
+    "works": [
+        {
+            "id": "9f6363b8-7df7-3732-b2b6-94c0f02e0bde",
+            "type": "Song",
+            "score": 100,
+            "title": "Poker Face",
+            "language": "eng",
+            "iswcs": ["T-901.751.548-9"],
+            "aliases": [
+                {
+                    "sort-name": "Poker Face (Tommy Sparks & The Fury remix)",
+                    "name": "Poker Face (Tommy Sparks & The Fury remix)",
+                    "locale": null,
+                    "type": null,
+                    "primary": null,
+                    "begin-date": null,
+                    "end-date": null
+                }
+            ],
+            "relations": [
+                {
+                    "type": "writer",
+                    "type-id": "a255bca1-b157-4518-9108-7b147dc3fc68",
+                    "target": "650e7db6-b795-4eb5-a702-5ea2fc46c848",
+                    "direction": "backward",
+                    "artist": {
+                        "id": "650e7db6-b795-4eb5-a702-5ea2fc46c848",
+                        "name": "Lady Gaga",
+                        "sort-name": "Lady Gaga"
+                    }
+                },
+                {
+                    "type": "writer",
+                    "type-id": "a255bca1-b157-4518-9108-7b147dc3fc68",
+                    "target": "8c84402d-f282-4afc-8d64-049bdaabb92d",
+                    "direction": "backward",
+                    "artist": {
+                        "id": "8c84402d-f282-4afc-8d64-049bdaabb92d",
+                        "name": "RedOne",
+                        "sort-name": "RedOne"
+                    }
+                },
+                {
+                    "type": "performance",
+                    "type-id": "a3005666-a872-32c3-ad06-98af558e99b0",
+                    "target": "f8bbe5a7-bc01-4780-aee0-aef98666b874",
+                    "direction": "backward",
+                    "recording": {
+                        "id": "f8bbe5a7-bc01-4780-aee0-aef98666b874",
+                        "title": "Poker Face (piano version)",
+                        "video": null
+                    }
+                }
+            ],
+            "languages": ["eng"]
+        }
+    ]
+}

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work-list.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work-list.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<metadata created="2026-01-14T04:52:47.571Z" xmlns="http://musicbrainz.org/ns/mmd-2.0#" xmlns:ns2="http://musicbrainz.org/ns/ext#-2.0">
+	<work-list count="1" offset="0">
+		<work id="9f6363b8-7df7-3732-b2b6-94c0f02e0bde" type="Song" type-id="f061270a-2fd6-32f1-a641-f0f8676d14e6" ns2:score="100">
+			<title>Poker Face</title>
+			<language>eng</language>
+			<language-list>
+				<language>eng</language>
+			</language-list>
+			<iswc-list>
+				<iswc>T-901.751.548-9</iswc>
+			</iswc-list>
+			<alias-list>
+				<alias sort-name="Poker Face (Tommy Sparks &amp; The Fury remix)">Poker Face (Tommy Sparks &amp; The Fury remix)</alias>
+			</alias-list>
+			<relation-list target-type="artist">
+				<relation type="writer" type-id="a255bca1-b157-4518-9108-7b147dc3fc68">
+					<target>650e7db6-b795-4eb5-a702-5ea2fc46c848</target>
+					<direction>backward</direction>
+					<artist id="650e7db6-b795-4eb5-a702-5ea2fc46c848">
+						<name>Lady Gaga</name>
+						<sort-name>Lady Gaga</sort-name>
+					</artist>
+				</relation>
+				<relation type="writer" type-id="a255bca1-b157-4518-9108-7b147dc3fc68">
+					<target>8c84402d-f282-4afc-8d64-049bdaabb92d</target>
+					<direction>backward</direction>
+					<artist id="8c84402d-f282-4afc-8d64-049bdaabb92d">
+						<name>RedOne</name>
+						<sort-name>RedOne</sort-name>
+					</artist>
+				</relation>
+			</relation-list>
+			<relation-list target-type="recording">
+				<relation type="performance" type-id="a3005666-a872-32c3-ad06-98af558e99b0">
+					<target>f8bbe5a7-bc01-4780-aee0-aef98666b874</target>
+					<direction>backward</direction>
+					<attribute-list/>
+					<recording id="f8bbe5a7-bc01-4780-aee0-aef98666b874">
+						<title>Poker Face (piano version)</title>
+					</recording>
+				</relation>
+			</relation-list>
+		</work>
+	</work-list>
+</metadata>

--- a/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work.xml
+++ b/mb-solr/src/test/resources/org/musicbrainz/search/solrwriter/work.xml
@@ -1,0 +1,41 @@
+<work xmlns="http://musicbrainz.org/ns/mmd-2.0#" id="9f6363b8-7df7-3732-b2b6-94c0f02e0bde" type="Song" type-id="f061270a-2fd6-32f1-a641-f0f8676d14e6">
+	<title>Poker Face</title>
+	<language>eng</language>
+	<language-list>
+		<language>eng</language>
+	</language-list>
+	<iswc-list>
+		<iswc>T-901.751.548-9</iswc>
+	</iswc-list>
+	<alias-list>
+		<alias sort-name="Poker Face (Tommy Sparks &amp; The Fury remix)">Poker Face (Tommy Sparks &amp; The Fury remix)</alias>
+	</alias-list>
+	<relation-list target-type="artist">
+		<relation type="writer" type-id="a255bca1-b157-4518-9108-7b147dc3fc68">
+			<target>650e7db6-b795-4eb5-a702-5ea2fc46c848</target>
+			<direction>backward</direction>
+			<artist id="650e7db6-b795-4eb5-a702-5ea2fc46c848">
+				<name>Lady Gaga</name>
+				<sort-name>Lady Gaga</sort-name>
+			</artist>
+		</relation>
+		<relation type="writer" type-id="a255bca1-b157-4518-9108-7b147dc3fc68">
+			<target>8c84402d-f282-4afc-8d64-049bdaabb92d</target>
+			<direction>backward</direction>
+			<artist id="8c84402d-f282-4afc-8d64-049bdaabb92d">
+				<name>RedOne</name>
+				<sort-name>RedOne</sort-name>
+			</artist>
+		</relation>
+	</relation-list>
+	<relation-list target-type="recording">
+		<relation type="performance" type-id="a3005666-a872-32c3-ad06-98af558e99b0">
+			<target>f8bbe5a7-bc01-4780-aee0-aef98666b874</target>
+			<direction>backward</direction>
+			<attribute-list/>
+			<recording id="f8bbe5a7-bc01-4780-aee0-aef98666b874">
+				<title>Poker Face (piano version)</title>
+			</recording>
+		</relation>
+	</relation-list>
+</work>


### PR DESCRIPTION
This adds the `target-type` property to event and work relationships, which is present in the JSON output of musicbrainz-server.

Extending the `RelationAdapter` usage to areas and URLs would fix SEARCH-444, but is a larger breaking change, which is why this only applies to events and works.

Tested via manual queries on my local search server, and by adding to or updating existing tests.