### PR TITLE
feat: build and push image for amd and arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hence, it is currently recommended to provision at least 250 GB of disk space fo
 
 Recommendations:
 * RAM: 4 GB
-* CPU: 8 threads, x86-64 architecture
+* CPU: 8 threads, amd64 (x86-64) or arm64 (aarch64) architecture
 * Disk Space: 250 GB (or 100 GB if you don't load backups.)
 
 Required software:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Otherwise, if you need it to be tested with either the indexer or MusicBrainz Se
 4. Build a docker image:
 
    ```bash
-   ./build.sh
+   ./build.sh --local-platform
    ```
 
 5. Use this tag to [set `MB_SOLR_VERSION` in MusicBrainz Docker Compose project](https://github.com/metabrainz/musicbrainz-docker?tab=readme-ov-file#local-development-of-musicbrainz-solr).

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,46 @@
 
 set -e -u
 
+SCRIPT_NAME=$(basename "$0")
+HELP=$(cat <<EOH
+Usage: $SCRIPT_NAME [--help|--local-platform]
+
+Options:
+  --help                Print this help message
+
+  --local-platform      Build image to run on the host platform only.
+                        This is intended for local development and testing,
+                        to skip building images for unnecessary targets.
+
+                        Do not use it to build image for a public repository.
+
+  Notes:
+    For multi-platform builds, there are some prerequisites to the host; see:
+    https://docs.docker.com/build/building/multi-platform/
+EOH
+)
+
+if [[ $# -eq 0 ]]
+then
+  platform_option='--platform linux/arm64,linux/amd64'
+elif [[ $# -gt 1 ]]
+then
+  echo >&2 "$SCRIPT_NAME: too many arguments"
+  echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+  exit 64 # EX_USAGE
+elif [[ $1 =~ -*h(elp)? ]]
+then
+  echo "$HELP"
+  exit 0 # EX_OK
+elif [[ $1 =~ --local-platform ]]
+then
+  platform_option=''
+else
+  echo >&2 "$SCRIPT_NAME: unknown option: '$1'"
+  echo >&2 "Try '$SCRIPT_NAME --help' for usage."
+  exit 64 # EX_USAGE
+fi
+
 image_name='metabrainz/mb-solr'
 
 cd "$(dirname "${BASH_SOURCE[0]}")/"
@@ -42,6 +82,6 @@ ${DOCKER_CMD} buildx build \
   --build-arg MB_SOLR_VERSION=${version} \
   --build-arg BUILD_DATE=${timestamp} \
   --build-arg VCS_REF=${vcs_ref} \
-  --platform linux/arm64,linux/amd64 \
+  ${platform_option} \
   --tag ${image_name}:${tag} . \
   2>&1 | tee ./"build-${version}-at-${timestamp}.log"

--- a/build.sh
+++ b/build.sh
@@ -38,9 +38,10 @@ fi
 tag=${version}
 timestamp=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
-${DOCKER_CMD} build \
+${DOCKER_CMD} buildx build \
   --build-arg MB_SOLR_VERSION=${version} \
   --build-arg BUILD_DATE=${timestamp} \
   --build-arg VCS_REF=${vcs_ref} \
+  --platform linux/arm64,linux/amd64 \
   --tag ${image_name}:${tag} . \
   2>&1 | tee ./"build-${version}-at-${timestamp}.log"


### PR DESCRIPTION
Build and push the arm64 version of mb-solr image using buildx.

Prerequisite: register an arm64 builder with `docker run --privileged --rm tonistiigi/binfmt --install arm64`