### PR TITLE
load-backup-archives: restore collections asynchronously and verify completion

### DIFF
--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -111,7 +111,7 @@ do
 	# Submit the restore asynchronously: the synchronous Collections API call
 	# hard-times-out after 180 seconds server-side, which large collections
 	# (release-group, url, recording) routinely exceed.
-	async_id="load-backup-$collection-$$"
+	async_id="load-backup-$collection-pid$$-ts$(date +%s)"
 	restore_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=RESTORE&collection=$collection&name=$collection&location=$SOLR_BACKUPS_DIR&async=$async_id")"
 	if [[ "$(echo "$restore_output" | jq -r .responseHeader.status)" != '0' ]]
 	then

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -131,7 +131,10 @@ do
 				break
 				;;
 			running|submitted)
-				continue
+				if (( poll_attempt % 6 == 1 ))
+				then
+					echo "$SCRIPT_NAME: $(date): Still waiting for the restore of the collection '$collection' to complete (state: $restore_state, attempt $poll_attempt/$MAX_POLL)..."
+				fi
 				;;
 			failed|notfound)
 				echo >&2 "$SCRIPT_NAME: Fatal error while restoring the collection '$collection' (async state: $restore_state):"

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -110,11 +110,7 @@ do
 	echo "$SCRIPT_NAME: $(date): Restore the collection '$collection' from extracted backup..."
 	# Submit the restore asynchronously: the synchronous Collections API call
 	# hard-times-out after 180 seconds server-side, which large collections
-	# (release-group, url, recording) routinely exceed. The previous status
-	# check also accepted error responses, because `=~ 0` is a substring
-	# match and "500" contains "0"; the backup files were then deleted from
-	# under the still-running background restore, leaving the collection
-	# silently empty.
+	# (release-group, url, recording) routinely exceed.
 	async_id="load-backup-$collection-$$"
 	restore_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=RESTORE&collection=$collection&name=$collection&location=$SOLR_BACKUPS_DIR&async=$async_id")"
 	if [[ "$(echo "$restore_output" | jq -r .responseHeader.status)" != '0' ]]

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -127,10 +127,23 @@ do
 			completed)
 				break
 				;;
+			running|submitted)
+				continue
+				;;
 			failed|notfound)
 				echo >&2 "$SCRIPT_NAME: Fatal error while restoring the collection '$collection' (async state: $restore_state):"
 				echo >&2 "$(echo "$status_output" | jq -r '.status.msg // .error.msg // .')"
 				exit 70 # EX_SOFTWARE
+				;;
+			null)
+				echo >&2 "$SCRIPT_NAME: No restore state for the collection '$collection'; Solr response:"
+				echo >&2 "$(echo "$status_output" | jq .)"
+				exit 75 # EX_TEMPFAIL
+				;;
+			*)
+				echo >&2 "$SCRIPT_NAME: Unknown restore state '$restore_state' for the collection '$collection'; Solr response:"
+				echo >&2 "$(echo "$status_output" | jq .)"
+				exit 76 # EX_PROTOCOL
 				;;
 		esac
 	done

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -155,7 +155,12 @@ do
 			exit 75 # EX_TEMPFAIL
 		fi
 	done
-	curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=DELETESTATUS&requestid=$async_id" > /dev/null
+	deletestatus_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=DELETESTATUS&requestid=$async_id")"
+	if [[ "$(echo "$deletestatus_output" | jq -r .responseHeader.status)" != '0' ]]
+	then
+		echo >&2 "$SCRIPT_NAME: Warning: failed to delete async status for '$async_id':"
+		echo >&2 "$(echo "$deletestatus_output" | jq -r '.error.msg // .')"
+	fi
 
 	echo "$SCRIPT_NAME: $(date): Delete the no-longer-needed extracted backup '$collection'..."
 	find "$SOLR_BACKUPS_DIR/$collection" -type f -delete

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -102,13 +102,38 @@ do
 	tar -x --zstd -f "$DUMP_DIR/$dump_file" -C "$SOLR_BACKUPS_DIR" "$collection/$collection"
 
 	echo "$SCRIPT_NAME: $(date): Restore the collection '$collection' from extracted backup..."
-	restore_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=RESTORE&collection=$collection&name=$collection&location=$SOLR_BACKUPS_DIR")"
-	if [[ ! "$(echo "$restore_output" | jq .responseHeader.status)" =~ 0 ]]
+	# Submit the restore asynchronously: the synchronous Collections API call
+	# hard-times-out after 180 seconds server-side, which large collections
+	# (release-group, url, recording) routinely exceed. The previous status
+	# check also accepted error responses, because `=~ 0` is a substring
+	# match and "500" contains "0"; the backup files were then deleted from
+	# under the still-running background restore, leaving the collection
+	# silently empty.
+	async_id="load-backup-$collection-$$"
+	restore_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=RESTORE&collection=$collection&name=$collection&location=$SOLR_BACKUPS_DIR&async=$async_id")"
+	if [[ "$(echo "$restore_output" | jq -r .responseHeader.status)" != 0 ]]
 	then
-		echo >&2 "$SCRIPT_NAME: Fatal error while restoring the collection '$collection':"
+		echo >&2 "$SCRIPT_NAME: Fatal error while submitting the restore of the collection '$collection':"
 		echo >&2 "$(echo "$restore_output" | jq .error.code): $(echo "$restore_output" | jq -r .error.msg)"
 		exit 70 # EX_SOFTWARE
 	fi
+	while true
+	do
+		sleep 10
+		status_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=REQUESTSTATUS&requestid=$async_id")"
+		restore_state="$(echo "$status_output" | jq -r .status.state)"
+		case "$restore_state" in
+			completed)
+				break
+				;;
+			failed|notfound)
+				echo >&2 "$SCRIPT_NAME: Fatal error while restoring the collection '$collection' (async state: $restore_state):"
+				echo >&2 "$(echo "$status_output" | jq -r '.status.msg // .error.msg // .')"
+				exit 70 # EX_SOFTWARE
+				;;
+		esac
+	done
+	curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=DELETESTATUS&requestid=$async_id" > /dev/null
 
 	echo "$SCRIPT_NAME: $(date): Delete the no-longer-needed extracted backup '$collection'..."
 	find "$SOLR_BACKUPS_DIR/$collection" -type f -delete

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2005
 
 set -e -o pipefail -u
 

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -4,6 +4,7 @@
 set -e -o pipefail -u
 
 DUMP_DIR="${MUSICBRAINZ_SEARCH_DUMP_DIR:-/var/cache/musicbrainz/solr-backups}"
+MAX_POLL="${MUSICBRAINZ_SEARCH_MAX_POLL:-360}" # 360 × 10s = 1h
 SOLR_BACKUPS_DIR="${SOLR_BACKUPS_DIR:-/var/solr/data/backups}"
 SOLR_BASE_URL="http://${SOLR_LOCAL_HOST:-localhost}:${SOLR_PORT:-8983}"
 
@@ -19,6 +20,10 @@ Options:
 Environment:
   MUSICBRAINZ_SEARCH_DUMP_DIR   path to directory with Solr backup tar archives
                                 (default: /var/cache/musicbrainz/solr-backups)
+  MUSICBRAINZ_SEARCH_MAX_POLL   maximum number of polling attempts for
+                                asynchronous requests sent to the Solr API,
+                                with a pause of 10s between each attempt
+                                (default: 360 attempts, that is about 1h)
   SOLR_BACKUPS_DIR              path to directory with Solr backup files
                                 (default: /var/solr/data/backups)
   SOLR_LOCAL_HOST               upstream Solr server listening host
@@ -118,9 +123,11 @@ do
 		echo >&2 "$(echo "$restore_output" | jq .error.code): $(echo "$restore_output" | jq -r .error.msg)"
 		exit 70 # EX_SOFTWARE
 	fi
+	poll_attempt=0
 	while true
 	do
 		sleep 10
+		poll_attempt=$((poll_attempt + 1))
 		status_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=REQUESTSTATUS&requestid=$async_id")"
 		restore_state="$(echo "$status_output" | jq -r .status.state)"
 		case "$restore_state" in
@@ -146,6 +153,11 @@ do
 				exit 76 # EX_PROTOCOL
 				;;
 		esac
+		if [[ $poll_attempt -ge $MAX_POLL ]]
+		then
+			echo >&2 "$SCRIPT_NAME: Timed out waiting for restore of the collection '$collection' (after $((MAX_POLL * 10)) seconds)"
+			exit 75 # EX_TEMPFAIL
+		fi
 	done
 	curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=DELETESTATUS&requestid=$async_id" > /dev/null
 

--- a/docker/scripts/load-backup-archives
+++ b/docker/scripts/load-backup-archives
@@ -117,7 +117,7 @@ do
 	# silently empty.
 	async_id="load-backup-$collection-$$"
 	restore_output="$(curl -sS "$SOLR_BASE_URL/solr/admin/collections?action=RESTORE&collection=$collection&name=$collection&location=$SOLR_BACKUPS_DIR&async=$async_id")"
-	if [[ "$(echo "$restore_output" | jq -r .responseHeader.status)" != 0 ]]
+	if [[ "$(echo "$restore_output" | jq -r .responseHeader.status)" != '0' ]]
 	then
 		echo >&2 "$SCRIPT_NAME: Fatal error while submitting the restore of the collection '$collection':"
 		echo >&2 "$(echo "$restore_output" | jq .error.code): $(echo "$restore_output" | jq -r .error.msg)"


### PR DESCRIPTION
## Problem

`load-backup-archives` can report success while leaving large collections silently empty. Three compounding issues:

1. The synchronous Collections API `RESTORE` call hard-times-out server-side after 180 seconds (`restore the collection time out:180s`, SolrException, HTTP 500). Large collections — `release-group`, `url`, and especially `recording` — routinely exceed that on modest hardware; `artist`/`release` only survive when they finish under the limit.
2. The status check `[[ ! "$(... | jq .responseHeader.status)" =~ 0 ]]` is a substring match, and `"500"` contains `"0"`, so the timeout error response passes the check.
3. The script then immediately deletes the extracted backup files — out from under the restore that is still running in the background on the Solr side — so the restore aborts and the collection ends up empty with a clean-looking log.

Observed live on a musicbrainz-docker deployment (2026-06): after a full `load-backup-archives` run that logged success for all 14 collections, `release-group` and `url` had `numDocs=0` while `artist` (2.89M) and `release` (5.55M) were fine. Re-running those two restores with `&async=` + `REQUESTSTATUS` polling loaded them correctly (4.33M and 19.6M docs).

## Fix

Submit the restore with `async=<request-id>`, poll `REQUESTSTATUS` every 10s until a terminal state, fail loudly on `failed`/`notfound`, and only after `completed` clean up the request status and the extracted backup files. The submit-time status check is now an exact comparison.

Happy to adjust style/poll cadence to project preferences.